### PR TITLE
admin tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,7 @@ Python3 command line script providing various tools for accessing CHADO database
 
 Download the latest release from this github repository, or clone the repository to obtain the most recent updates.
 
-Modify the file with [default connection settings](pychado/data/defaultDatabase.yml) such that it contains an existing PostgreSQL database to which you can connect.
-Note: This database is only used for housekeeping purposes, it will never be changed or removed by `chado-tools`. You can thus simply use one of the built-in PostgreSQL databases, such as `postgres`.
+Modify the file with [default connection settings](pychado/data/defaultDatabase.yml) such that it contains the settings for and existing PostgreSQL database server to which you can connect.
 
 Then run the tests:
 
@@ -56,26 +55,24 @@ The usage is:
 | init                  | set the default connection parameters                                |
 | reset                 | reset the default connection parameters to factory settings          |
 | connect               | connect to a CHADO database for an interactive session               |
-| create                | create a new instance of the CHADO schema                            |
-| dump                  | dump a CHADO database into an archive file                           |
-| restore               | restore a CHADO database from an archive file                        |
 | query                 | query a CHADO database and export the result into a text file        |
 | stats                 | obtain statistics to updates in a CHADO database                     |
 | list                  | list all entities of a specified type in the CHADO database          |
 | insert                | insert a new entity of a specified type into the CHADO database      |
 | delete                | delete an entity of a specified type from the CHADO database         |
 | import                | import entities of a specified type into the CHADO database          |
+| admin                 | perform admin tasks, such as creating or dumping a CHADO database    |
 ------------------------------------------------------------------------------------------------
 
 ## Examples
 
 Create a new CHADO database called `eukaryotes` according to the current GMOD schema:
 
-    chado create eukaryotes
+    chado admin create eukaryotes
     
 Dump this database into an archive called `eukaryotes.dump`:
 
-    chado dump eukaryotes eukaryotes.dump
+    chado admin dump eukaryotes eukaryotes.dump
 
 List all organisms in the `eukaryotes` database:
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Python3 command line script providing various tools for accessing CHADO database
 
 Download the latest release from this github repository, or clone the repository to obtain the most recent updates.
 
-Modify the file with [default connection settings](pychado/data/defaultDatabase.yml) such that it contains the settings for and existing PostgreSQL database server to which you can connect.
+Modify the file with [default connection settings](pychado/data/defaultDatabase.yml) such that it contains the settings for an existing PostgreSQL database server to which you can connect.
 
 Then run the tests:
 

--- a/pychado/dbutils.py
+++ b/pychado/dbutils.py
@@ -153,20 +153,6 @@ def setup_database(uri: str, schema_file: str) -> None:
     print("Database schema has been set up.")
 
 
-def dump_users(uri: str, filename: str) -> None:
-    """Exports a list of database users to file"""
-    command = ["pg_dumpall", "-d", uri, "--roles-only", "-f", filename]
-    subprocess.run(command)
-    print("Database users have been exported to file.")
-
-
-def restore_users(uri: str, filename: str) -> None:
-    """Imports a list of database users from file"""
-    command = ["psql", "-q", "-f", filename, uri]
-    subprocess.run(command)
-    print("Database users have been imported from file.")
-
-
 def connect_to_database(uri: str) -> None:
     """Connects to a database for an interactive session"""
     print("Establishing connection to database...")

--- a/pychado/dbutils.py
+++ b/pychado/dbutils.py
@@ -136,12 +136,10 @@ def dump_database(uri: str, archive: str) -> None:
     print("Database has been dumped.")
 
 
-def restore_database(uri: str, archive: str, remove_privileges=True) -> None:
+def restore_database(uri: str, archive: str) -> None:
     """Restores a database from an archive file"""
-    command = ["pg_restore", "--clean", "--if-exists"]
-    if remove_privileges:
-        command.extend(["--no-owner", "--no-privileges"])
-    command.extend(["--format=custom", "-d", uri, archive])
+    command = ["pg_restore", "--clean", "--if-exists", "--no-owner", "--no-privileges", "--format=custom",
+               "-d", uri, archive]
     subprocess.run(command)
     print("Database has been restored.")
 

--- a/pychado/queries.py
+++ b/pychado/queries.py
@@ -76,13 +76,13 @@ def specify_list_parameters(specifier: str, arguments) -> dict:
             params["cv_name"] = arguments.vocabulary
         if arguments.database != "all":
             params["database_name"] = arguments.database
-    elif specifier == "products":
+    elif specifier == "genedb_products":
         if arguments.organism != "all":
             params["organism"] = arguments.organism
     elif specifier == "organisms":
         pass
     else:
-        print("Functionality 'insert " + specifier + "' is not yet implemented.")
+        print("Functionality 'list " + specifier + "' is not yet implemented.")
     return params
 
 

--- a/pychado/tasks.py
+++ b/pychado/tasks.py
@@ -69,12 +69,6 @@ def run_command_with_arguments(command: str, sub_command: str, arguments, connec
         # Restore a PostgreSQL database from an archive file
         dbutils.create_database(connection_uri)
         dbutils.restore_database(connection_uri, arguments.archive)
-    elif command == "admin" and sub_command == "dump_users":
-        # Export the users of a PostgreSQL database server to file
-        dbutils.dump_users(connection_uri, arguments.file)
-    elif command == "admin" and sub_command == "restore_users":
-        # Import the users of a PostgreSQL database server from file
-        dbutils.restore_users(connection_uri, arguments.file)
     elif command == "query":
         # Query a PostgreSQL database and export the result to a text file
         if arguments.query:

--- a/pychado/tasks.py
+++ b/pychado/tasks.py
@@ -2,18 +2,19 @@ from pychado import utils, dbutils, queries
 from pychado.io import load_ontology
 
 
-def read_configuration_file(filename: str) -> dict:
-    """Reads data from a configuration file into a dictionary"""
+def create_connection_string(filename: str, dbname: str) -> str:
+    """Reads database connection parameters from a configuration file and generates a connection string"""
     if not filename:
         filename = dbutils.default_configuration_file()
-    return utils.parse_yaml(filename)
+    connection_parameters = utils.parse_yaml(filename)
+    connection_parameters["database"] = dbname
+    return dbutils.generate_uri(connection_parameters)
 
 
-def check_access(connection_parameters: dict, database: str, task: str) -> bool:
+def check_access(connection_uri: str, task: str) -> bool:
     """Checks if the database of interest exists and is accessible. If the database doesn't exist, but the
     task implies its creation, create it. Otherwise exit the program."""
-    connection_uri = dbutils.generate_uri(connection_parameters)
-    exists = dbutils.exists(connection_uri, database)
+    exists = dbutils.exists(connection_uri)
     if exists:
         if task in ["create", "restore"]:
             # Database already exists, we should not overwrite it. Return without further action
@@ -24,8 +25,7 @@ def check_access(connection_parameters: dict, database: str, task: str) -> bool:
             return True
     else:
         if task in ["create", "restore"]:
-            # Database doesn't exist, but task implies its creation. Create it
-            dbutils.create_database(connection_uri, database)
+            # Database doesn't exist, but task implies its creation
             return True
         else:
             # Database doesn't exist, and task can't be completed. Return without further action
@@ -33,34 +33,48 @@ def check_access(connection_parameters: dict, database: str, task: str) -> bool:
             return False
 
 
-def run_command_with_arguments(command: str, sub_command: str, arguments, connection_parameters: dict) -> None:
-    """Runs a specified sub-command with the supplied arguments"""
-
-    # Create connection strings
-    connection_uri = dbutils.generate_uri(connection_parameters)
-
-    # Run the command
+def setup(command: str) -> None:
+    """Initiates or resets the default connection parameters"""
     if command == "init":
         # Set the default connection parameters
         dbutils.set_default_parameters()
     elif command == "reset":
         # Reset the default connection parameters to factory settings
         dbutils.reset_default_parameters()
-    elif command == "connect":
+    else:
+        print("Functionality '" + command + "' is not yet implemented.")
+
+
+def run_command_with_arguments(command: str, sub_command: str, arguments, connection_uri: str) -> None:
+    """Runs a specified sub-command with the supplied arguments"""
+
+    # Run the command
+    if command == "connect":
         # Connect to a PostgreSQL database for an interactive session
         dbutils.connect_to_database(connection_uri)
-    elif command == "create":
+    elif command == "admin" and sub_command == "create":
         # Setup a PostgreSQL database according to a schema
+        dbutils.create_database(connection_uri)
         schema = arguments.schema
         if not schema:
             schema = utils.download_file(dbutils.default_schema_url())
         dbutils.setup_database(connection_uri, schema)
-    elif command == "dump":
+    elif command == "admin" and sub_command == "drop":
+        # Drop a PostgreSQL database
+        dbutils.drop_database(connection_uri)
+    elif command == "admin" and sub_command == "dump":
         # Dump a PostgreSQL database into an archive file
         dbutils.dump_database(connection_uri, arguments.archive)
-    elif command == "restore":
+    elif command == "admin" and sub_command == "restore":
         # Restore a PostgreSQL database from an archive file
+        dbutils.create_database(connection_uri)
         dbutils.restore_database(connection_uri, arguments.archive)
+    elif command == "admin" and sub_command == "dump_users":
+        # Export the users of a PostgreSQL database server to file
+        dbutils.dump_users(connection_uri, arguments.file)
+    elif command == "admin" and sub_command == "restore_users":
+        # Import the users of a PostgreSQL database server from file
+        dbutils.restore_users(connection_uri, arguments.file)
     elif command == "query":
         # Query a PostgreSQL database and export the result to a text file
         if arguments.query:

--- a/pychado/tests/arguments_tests.py
+++ b/pychado/tests/arguments_tests.py
@@ -14,9 +14,6 @@ class TestCommands(unittest.TestCase):
     def test_general_commands(self):
         commands = chado_tools.general_commands()
         self.assertIn("connect", commands)
-        self.assertIn("create", commands)
-        self.assertIn("dump", commands)
-        self.assertIn("restore", commands)
         self.assertIn("query", commands)
         self.assertIn("stats", commands)
         self.assertNotIn("non_existent_command", commands)
@@ -27,7 +24,17 @@ class TestCommands(unittest.TestCase):
         self.assertIn("insert", commands)
         self.assertIn("delete", commands)
         self.assertIn("import", commands)
+        self.assertIn("admin", commands)
         self.assertNotIn("non_existent_command", commands)
+
+    def test_admin_commands(self):
+        commands = chado_tools.admin_commands()
+        self.assertIn("create", commands)
+        self.assertIn("drop", commands)
+        self.assertIn("dump", commands)
+        self.assertIn("restore", commands)
+        self.assertIn("dump_users", commands)
+        self.assertIn("restore_users", commands)
 
     def test_list_commands(self):
         commands = chado_tools.list_commands()
@@ -67,24 +74,45 @@ class TestArguments(unittest.TestCase):
         self.assertNotIn("non_existent_argument", parsed_args)
 
     def test_create_args(self):
-        # Tests if the command line arguments for the subcommand 'chado create' are parsed correctly
-        args = ["chado", "create", "-s", "testschema", "testdb"]
+        # Tests if the command line arguments for the subcommand 'chado admin create' are parsed correctly
+        args = ["chado", "admin", "create", "-s", "testschema", "testdb"]
         parsed_args = vars(chado_tools.parse_arguments(args))
+        self.assertEqual(parsed_args["dbname"], "testdb")
         self.assertEqual(parsed_args["schema"], "testschema")
 
+    def test_drop_args(self):
+        # Tests if the command line arguments for the subcommand 'chado admin drop' are parsed correctly
+        args = ["chado", "admin", "drop", "testdb"]
+        parsed_args = vars(chado_tools.parse_arguments(args))
+        self.assertEqual(parsed_args["dbname"], "testdb")
+
     def test_dump_args(self):
-        # Tests if the command line arguments for the subcommand 'chado dump' are parsed correctly
-        args = ["chado", "dump", "testdb", "testarchive"]
+        # Tests if the command line arguments for the subcommand 'chado admin dump' are parsed correctly
+        args = ["chado", "admin", "dump", "testdb", "testarchive"]
         parsed_args = vars(chado_tools.parse_arguments(args))
         self.assertEqual(parsed_args["dbname"], "testdb")
         self.assertEqual(parsed_args["archive"], "testarchive")
 
     def test_restore_args(self):
-        # Tests if the command line arguments for the subcommand 'chado restore' are parsed correctly
-        args = ["chado", "restore", "testdb", "testarchive"]
+        # Tests if the command line arguments for the subcommand 'chado admin restore' are parsed correctly
+        args = ["chado", "admin", "restore", "testdb", "testarchive"]
         parsed_args = vars(chado_tools.parse_arguments(args))
         self.assertEqual(parsed_args["dbname"], "testdb")
         self.assertEqual(parsed_args["archive"], "testarchive")
+
+    def test_dump_users_args(self):
+        # Tests if the command line arguments for the subcommand 'chado admin dump_users' are parsed correctly
+        args = ["chado", "admin", "dump_users", "testdb", "testfile"]
+        parsed_args = vars(chado_tools.parse_arguments(args))
+        self.assertEqual(parsed_args["dbname"], "testdb")
+        self.assertEqual(parsed_args["file"], "testfile")
+
+    def test_restore_users_args(self):
+        # Tests if the command line arguments for the subcommand 'chado admin restore_users' are parsed correctly
+        args = ["chado", "admin", "restore_users", "testdb", "testfile"]
+        parsed_args = vars(chado_tools.parse_arguments(args))
+        self.assertEqual(parsed_args["dbname"], "testdb")
+        self.assertEqual(parsed_args["file"], "testfile")
 
     def test_query_args(self):
         # Tests if the command line arguments for the subcommand 'chado query' are parsed correctly

--- a/pychado/tests/arguments_tests.py
+++ b/pychado/tests/arguments_tests.py
@@ -1,5 +1,5 @@
 import unittest
-from scripts import chado_tools
+from terminal import chado_tools
 
 
 class TestCommands(unittest.TestCase):
@@ -33,8 +33,6 @@ class TestCommands(unittest.TestCase):
         self.assertIn("drop", commands)
         self.assertIn("dump", commands)
         self.assertIn("restore", commands)
-        self.assertIn("dump_users", commands)
-        self.assertIn("restore_users", commands)
 
     def test_list_commands(self):
         commands = chado_tools.list_commands()
@@ -99,20 +97,6 @@ class TestArguments(unittest.TestCase):
         parsed_args = vars(chado_tools.parse_arguments(args))
         self.assertEqual(parsed_args["dbname"], "testdb")
         self.assertEqual(parsed_args["archive"], "testarchive")
-
-    def test_dump_users_args(self):
-        # Tests if the command line arguments for the subcommand 'chado admin dump_users' are parsed correctly
-        args = ["chado", "admin", "dump_users", "testdb", "testfile"]
-        parsed_args = vars(chado_tools.parse_arguments(args))
-        self.assertEqual(parsed_args["dbname"], "testdb")
-        self.assertEqual(parsed_args["file"], "testfile")
-
-    def test_restore_users_args(self):
-        # Tests if the command line arguments for the subcommand 'chado admin restore_users' are parsed correctly
-        args = ["chado", "admin", "restore_users", "testdb", "testfile"]
-        parsed_args = vars(chado_tools.parse_arguments(args))
-        self.assertEqual(parsed_args["dbname"], "testdb")
-        self.assertEqual(parsed_args["file"], "testfile")
 
     def test_query_args(self):
         # Tests if the command line arguments for the subcommand 'chado query' are parsed correctly

--- a/pychado/tests/queries_tests.py
+++ b/pychado/tests/queries_tests.py
@@ -107,12 +107,12 @@ class TestQueries(unittest.TestCase):
 
         # chado list products
         args = chado_tools.parse_arguments(["chado", "list", "genedb_products", "-a", "testorganism", "testdb"])
-        params = queries.specify_list_parameters("products", args)
+        params = queries.specify_list_parameters("genedb_products", args)
         self.assertEqual(len(params), 1)
         self.assertEqual(params["organism"], "testorganism")
 
         args = chado_tools.parse_arguments(["chado", "list", "genedb_products", "testdb"])
-        params = queries.specify_list_parameters("products", args)
+        params = queries.specify_list_parameters("genedb_products", args)
         self.assertEqual(len(params), 0)
 
     def test_specify_stats_parameters(self):

--- a/pychado/tests/queries_tests.py
+++ b/pychado/tests/queries_tests.py
@@ -1,6 +1,6 @@
 import unittest
 import pkg_resources
-from scripts import chado_tools
+from terminal import chado_tools
 from pychado import queries, utils
 
 

--- a/pychado/tests/tasks_tests.py
+++ b/pychado/tests/tasks_tests.py
@@ -8,97 +8,131 @@ class TestTasks(unittest.TestCase):
     """Tests the functionality of all commands of the CHADO program"""
 
     def setUp(self):
-        self.connectionParameters = tasks.read_configuration_file("")
-        self.uri = dbutils.generate_uri(self.connectionParameters)
-
-    def tearDown(self):
-        self.connectionParameters.clear()
+        self.uri = tasks.create_connection_string("", "testdb")
 
     @unittest.mock.patch('pychado.utils.parse_yaml')
     @unittest.mock.patch('pychado.dbutils.default_configuration_file')
-    def test_read_configuration_file(self, mock_default, mock_parse):
+    def test_create_connection_string(self, mock_default, mock_parse):
         # Checks that the default configuration file is used unless another file is supplied
         self.assertIs(mock_default, dbutils.default_configuration_file)
         self.assertIs(mock_parse, utils.parse_yaml)
 
         mock_default.return_value = "default_file"
-        tasks.read_configuration_file("")
+        tasks.create_connection_string("", "testdb")
         mock_default.assert_called()
         mock_parse.assert_called_with("default_file")
 
         mock_default.reset_mock()
         mock_parse.reset_mock()
-        tasks.read_configuration_file("user_supplied_file")
+        tasks.create_connection_string("user_supplied_file", "testdb")
         mock_default.assert_not_called()
         mock_parse.assert_called_with("user_supplied_file")
 
-    @unittest.mock.patch('pychado.dbutils.create_database')
     @unittest.mock.patch('pychado.dbutils.exists')
-    def test_access(self, mock_exist, mock_create):
+    def test_access(self, mock_exist):
         # Checks that database access is only permitted if the database exists or gets created,
         # and checks that no existing database is overwritten
         self.assertIs(mock_exist, dbutils.exists)
-        self.assertIs(mock_create, dbutils.create_database)
 
         mock_exist.return_value = True
-        self.assertTrue(tasks.check_access(self.connectionParameters, "testdb", "connect"))
-        mock_create.assert_not_called()
-        self.assertFalse(tasks.check_access(self.connectionParameters, "testdb", "create"))
-        mock_create.assert_not_called()
+        self.assertTrue(tasks.check_access(self.uri, "connect"))
+        self.assertFalse(tasks.check_access(self.uri, "create"))
 
         mock_exist.return_value = False
-        self.assertFalse(tasks.check_access(self.connectionParameters, "testdb", "connect"))
-        mock_create.assert_not_called()
-        self.assertTrue(tasks.check_access(self.connectionParameters, "testdb", "create"))
-        mock_create.assert_called_with(self.uri, "testdb")
-
-    @unittest.mock.patch('pychado.dbutils.set_default_parameters')
-    def test_init(self, mock_set):
-        # Checks that the function setting default connection parameters is correctly called
-        self.assertIs(mock_set, dbutils.set_default_parameters)
-        args = chado_tools.parse_arguments(["chado", "init"])
-        tasks.run_command_with_arguments("init", "", args, self.connectionParameters)
-        mock_set.assert_called()
+        self.assertFalse(tasks.check_access(self.uri, "connect"))
+        self.assertTrue(tasks.check_access(self.uri, "create"))
 
     @unittest.mock.patch('pychado.dbutils.reset_default_parameters')
-    def test_reset(self, mock_reset):
-        # Checks that the function resetting default connection parameters to factory state is correctly called
+    @unittest.mock.patch('pychado.dbutils.set_default_parameters')
+    def test_init_reset(self, mock_set, mock_reset):
+        # Checks that the functions setting/resetting default connection parameters are correctly called
+        self.assertIs(mock_set, dbutils.set_default_parameters)
         self.assertIs(mock_reset, dbutils.reset_default_parameters)
-        args = chado_tools.parse_arguments(["chado", "reset"])
-        tasks.run_command_with_arguments("reset", "", args, self.connectionParameters)
+
+        tasks.setup("init")
+        mock_set.assert_called()
+        mock_reset.assert_not_called()
+        mock_set.reset_mock()
+        mock_reset.reset_mock()
+
+        tasks.setup("reset")
+        mock_set.assert_not_called()
         mock_reset.assert_called()
+        mock_set.reset_mock()
+        mock_reset.reset_mock()
+
+        tasks.setup("non_existing_command")
+        mock_set.assert_not_called()
+        mock_reset.assert_not_called()
 
     @unittest.mock.patch('pychado.dbutils.connect_to_database')
     def test_connect(self, mock_connect):
         # Checks that the function establishing a connection is correctly called
         self.assertIs(mock_connect, dbutils.connect_to_database)
-        args = chado_tools.parse_arguments(["chado", "connect", "testdb"])
-        tasks.run_command_with_arguments("connect", "", args, self.connectionParameters)
+        args = ["chado", "connect", "testdb"]
+        parsed_args = chado_tools.parse_arguments(args)
+        tasks.run_command_with_arguments(args[1], "", parsed_args, self.uri)
         mock_connect.assert_called_with(self.uri)
 
     @unittest.mock.patch('pychado.dbutils.setup_database')
-    def test_create(self, mock_create):
-        # Checks that the function setting up a database is correctly called
-        self.assertIs(mock_create, dbutils.setup_database)
-        args = chado_tools.parse_arguments(["chado", "create", "-s", "testschema", "testdb"])
-        tasks.run_command_with_arguments("create", "", args, self.connectionParameters)
-        mock_create.assert_called_with(self.uri, "testschema")
+    @unittest.mock.patch('pychado.dbutils.create_database')
+    def test_create(self, mock_create, mock_setup):
+        # Checks that the function creating and setting up a database is correctly called
+        self.assertIs(mock_create, dbutils.create_database)
+        self.assertIs(mock_setup, dbutils.setup_database)
+        args = ["chado", "admin", "create", "-s", "testschema", "testdb"]
+        parsed_args = chado_tools.parse_arguments(args)
+        tasks.run_command_with_arguments(args[1], args[2], parsed_args, self.uri)
+        mock_create.assert_called_with(self.uri)
+        mock_setup.assert_called_with(self.uri, "testschema")
+
+    @unittest.mock.patch('pychado.dbutils.drop_database')
+    def test_drop(self, mock_drop):
+        # Checks that a function dropping a database is correctly called
+        self.assertIs(mock_drop, dbutils.drop_database)
+        args = ["chado", "admin", "drop", "testdb"]
+        parsed_args = chado_tools.parse_arguments(args)
+        tasks.run_command_with_arguments(args[1], args[2], parsed_args, self.uri)
+        mock_drop.assert_called_with(self.uri)
 
     @unittest.mock.patch('pychado.dbutils.dump_database')
     def test_dump(self, mock_dump):
         # Checks that the function dumping a database is correctly called
         self.assertIs(mock_dump, dbutils.dump_database)
-        args = chado_tools.parse_arguments(["chado", "dump", "testdb", "testarchive"])
-        tasks.run_command_with_arguments("dump", "", args, self.connectionParameters)
+        args = ["chado", "admin", "dump", "testdb", "testarchive"]
+        parsed_args = chado_tools.parse_arguments(args)
+        tasks.run_command_with_arguments(args[1], args[2], parsed_args, self.uri)
         mock_dump.assert_called_with(self.uri, "testarchive")
 
     @unittest.mock.patch('pychado.dbutils.restore_database')
-    def test_restore(self, mock_restore):
+    @unittest.mock.patch('pychado.dbutils.create_database')
+    def test_restore(self, mock_create, mock_restore):
         # Checks that the function restoring a database is correctly called
+        self.assertIs(mock_create, dbutils.create_database)
         self.assertIs(mock_restore, dbutils.restore_database)
-        args = chado_tools.parse_arguments(["chado", "restore", "testdb", "testarchive"])
-        tasks.run_command_with_arguments("restore", "", args, self.connectionParameters)
+        args = ["chado", "admin", "restore", "testdb", "testarchive"]
+        parsed_args = chado_tools.parse_arguments(args)
+        tasks.run_command_with_arguments(args[1], args[2], parsed_args, self.uri)
+        mock_create.assert_called_with(self.uri)
         mock_restore.assert_called_with(self.uri, "testarchive")
+
+    @unittest.mock.patch('pychado.dbutils.dump_users')
+    def test_dump_users(self, mock_dump):
+        # Checks that the function exporting a list of users is correctly called
+        self.assertIs(mock_dump, dbutils.dump_users)
+        args = ["chado", "admin", "dump_users", "testdb", "testfile"]
+        parsed_args = chado_tools.parse_arguments(args)
+        tasks.run_command_with_arguments(args[1], args[2], parsed_args, self.uri)
+        mock_dump.assert_called_with(self.uri, "testfile")
+
+    @unittest.mock.patch('pychado.dbutils.restore_users')
+    def test_restore_users(self, mock_restore):
+        # Checks that the function importing a list of users is correctly called
+        self.assertIs(mock_restore, dbutils.restore_users)
+        args = ["chado", "admin", "restore_users", "testdb", "testfile"]
+        parsed_args = chado_tools.parse_arguments(args)
+        tasks.run_command_with_arguments(args[1], args[2], parsed_args, self.uri)
+        mock_restore.assert_called_with(self.uri, "testfile")
 
     @unittest.mock.patch('pychado.utils.read_text')
     @unittest.mock.patch('pychado.dbutils.query_to_file')
@@ -107,15 +141,15 @@ class TestTasks(unittest.TestCase):
         self.assertIs(mock_query, dbutils.query_to_file)
         self.assertIs(mock_read, utils.read_text)
         # Direct query
-        args = chado_tools.parse_arguments(["chado", "query", "-H", "-d", ";", "-o", "testfile", "-q", "testquery",
-                                            "testdb"])
-        tasks.run_command_with_arguments("query", "", args, self.connectionParameters)
+        args = ["chado", "query", "-H", "-d", ";", "-o", "testfile", "-q", "testquery", "testdb"]
+        parsed_args = chado_tools.parse_arguments(args)
+        tasks.run_command_with_arguments(args[1], "", parsed_args, self.uri)
         mock_query.assert_called_with(self.uri, "testquery", {}, "testfile", ";", True)
         # Query extracted from file
-        args = chado_tools.parse_arguments(["chado", "query", "-d", ";", "-o", "testfile", "-f", "testqueryfile",
-                                            "testdb"])
+        args = ["chado", "query", "-d", ";", "-o", "testfile", "-f", "testqueryfile", "testdb"]
+        parsed_args = chado_tools.parse_arguments(args)
         mock_read.return_value = "query_from_file"
-        tasks.run_command_with_arguments("query", "", args, self.connectionParameters)
+        tasks.run_command_with_arguments(args[1], "", parsed_args, self.uri)
         mock_query.assert_called_with(self.uri, "query_from_file", {}, "testfile", ";", False)
 
     @unittest.mock.patch('pychado.queries.specify_stats_parameters')
@@ -126,11 +160,11 @@ class TestTasks(unittest.TestCase):
         self.assertIs(mock_query, dbutils.query_to_file)
         self.assertIs(mock_load, queries.load_stats_query)
         self.assertIs(mock_specify, queries.specify_stats_parameters)
-        args = chado_tools.parse_arguments(["chado", "stats", "-H", "-d", ";", "-o", "testfile", "--start_date",
-                                            "testdate", "testdb"])
+        args = ["chado", "stats", "-H", "-d", ";", "-o", "testfile", "--start_date", "testdate", "testdb"]
+        parsed_args = chado_tools.parse_arguments(args)
         mock_load.return_value = "testquery"
         mock_specify.return_value = {"testkey": "testvalue"}
-        tasks.run_command_with_arguments("stats", "", args, self.connectionParameters)
+        tasks.run_command_with_arguments(args[1], "", parsed_args, self.uri)
         mock_query.assert_called_with(self.uri, "testquery", {"testkey": "testvalue"}, "testfile", ";", True)
 
     @unittest.mock.patch('pychado.queries.specify_list_parameters')
@@ -141,10 +175,11 @@ class TestTasks(unittest.TestCase):
         self.assertIs(mock_query, dbutils.query_to_file)
         self.assertIs(mock_load, queries.load_list_query)
         self.assertIs(mock_specify, queries.specify_list_parameters)
-        args = chado_tools.parse_arguments(["chado", "list", "organisms", "-H", "-d", ";", "-o", "testfile", "testdb"])
+        args = ["chado", "list", "organisms", "-H", "-d", ";", "-o", "testfile", "testdb"]
+        parsed_args = chado_tools.parse_arguments(args)
         mock_load.return_value = "testquery"
         mock_specify.return_value = {"testkey": "testvalue"}
-        tasks.run_command_with_arguments("list", "organisms", args, self.connectionParameters)
+        tasks.run_command_with_arguments(args[1], args[2], parsed_args, self.uri)
         mock_query.assert_called_with(self.uri, "testquery", {"testkey": "testvalue"}, "testfile", ";", True)
 
     @unittest.mock.patch('pychado.queries.specify_list_parameters')
@@ -155,10 +190,11 @@ class TestTasks(unittest.TestCase):
         self.assertIs(mock_query, dbutils.query_to_file)
         self.assertIs(mock_load, queries.load_list_query)
         self.assertIs(mock_specify, queries.specify_list_parameters)
-        args = chado_tools.parse_arguments(["chado", "list", "cvterms", "-H", "-d", ";", "-o", "testfile", "testdb"])
+        args = ["chado", "list", "cvterms", "-H", "-d", ";", "-o", "testfile", "testdb"]
+        parsed_args = chado_tools.parse_arguments(args)
         mock_load.return_value = "testquery"
         mock_specify.return_value = {"testkey": "testvalue"}
-        tasks.run_command_with_arguments("list", "cvterms", args, self.connectionParameters)
+        tasks.run_command_with_arguments(args[1], args[2], parsed_args, self.uri)
         mock_query.assert_called_with(self.uri, "testquery", {"testkey": "testvalue"}, "testfile", ";", True)
 
     @unittest.mock.patch('pychado.queries.specify_list_parameters')
@@ -169,11 +205,11 @@ class TestTasks(unittest.TestCase):
         self.assertIs(mock_query, dbutils.query_to_file)
         self.assertIs(mock_load, queries.load_list_query)
         self.assertIs(mock_specify, queries.specify_list_parameters)
-        args = chado_tools.parse_arguments(["chado", "list", "genedb_products", "-H", "-d", ";", "-o", "testfile",
-                                            "testdb"])
+        args = ["chado", "list", "genedb_products", "-H", "-d", ";", "-o", "testfile", "testdb"]
+        parsed_args = chado_tools.parse_arguments(args)
         mock_load.return_value = "testquery"
         mock_specify.return_value = {"testkey": "testvalue"}
-        tasks.run_command_with_arguments("list", "products", args, self.connectionParameters)
+        tasks.run_command_with_arguments(args[1], args[2], parsed_args, self.uri)
         mock_query.assert_called_with(self.uri, "testquery", {"testkey": "testvalue"}, "testfile", ";", True)
 
     @unittest.mock.patch('pychado.queries.specify_insert_parameters')
@@ -184,11 +220,11 @@ class TestTasks(unittest.TestCase):
         self.assertIs(mock_statement, dbutils.connect_and_execute)
         self.assertIs(mock_load, queries.load_insert_statement)
         self.assertIs(mock_specify, queries.specify_insert_parameters)
-        args = chado_tools.parse_arguments(["chado", "insert", "organism", "-g", "testgenus", "-s", "testspecies",
-                                            "-a", "testabbreviation", "testdb"])
+        args = ["chado", "insert", "organism", "-g", "testgenus", "-s", "testspecies", "-a", "testorganism", "testdb"]
+        parsed_args = chado_tools.parse_arguments(args)
         mock_load.return_value = "teststatement"
         mock_specify.return_value = {"testkey": "testvalue"}
-        tasks.run_command_with_arguments("insert", "organism", args, self.connectionParameters)
+        tasks.run_command_with_arguments(args[1], args[2], parsed_args, self.uri)
         mock_statement.assert_called_with(self.uri, "teststatement", {"testkey": "testvalue"})
 
     @unittest.mock.patch('pychado.queries.specify_delete_parameters')
@@ -199,20 +235,21 @@ class TestTasks(unittest.TestCase):
         self.assertIs(mock_statement, dbutils.connect_and_execute)
         self.assertIs(mock_load, queries.load_delete_statement)
         self.assertIs(mock_specify, queries.specify_delete_parameters)
-        args = chado_tools.parse_arguments(["chado", "delete", "organism", "-a", "testorganism", "testdb"])
+        args = ["chado", "delete", "organism", "-a", "testorganism", "testdb"]
+        parsed_args = chado_tools.parse_arguments(args)
         mock_load.return_value = "teststatement"
         mock_specify.return_value = {"testkey": "testvalue"}
-        tasks.run_command_with_arguments("delete", "organism", args, self.connectionParameters)
+        tasks.run_command_with_arguments(args[1], args[2], parsed_args, self.uri)
         mock_statement.assert_called_with(self.uri, "teststatement", {"testkey": "testvalue"})
 
     @unittest.mock.patch('pychado.tasks.run_import_command')
     def test_run_import(self, mock_run):
         # Checks that database imports are correctly run
         self.assertIs(mock_run, tasks.run_import_command)
-        args = chado_tools.parse_arguments(["chado", "import", "ontology", "-f", "testfile", "-A",
-                                            "testauthority", "-F", "owl", "testdb"])
-        tasks.run_command_with_arguments("import", "ontology", args, self.connectionParameters)
-        mock_run.assert_called_with("ontology", args, self.uri)
+        args = ["chado", "import", "ontology", "-f", "testfile", "-A", "testauthority", "-F", "owl", "testdb"]
+        parsed_args = chado_tools.parse_arguments(args)
+        tasks.run_command_with_arguments(args[1], args[2], parsed_args, self.uri)
+        mock_run.assert_called_with("ontology", parsed_args, self.uri)
 
     @unittest.mock.patch('pychado.utils.download_file')
     @unittest.mock.patch('pychado.io.load_ontology.OntologyLoader.load')
@@ -220,17 +257,17 @@ class TestTasks(unittest.TestCase):
         # Checks that the function importing an ontology into the database is correctly called
         self.assertIs(mock_import, load_ontology.OntologyLoader.load)
         self.assertIs(mock_download, utils.download_file)
-        args = chado_tools.parse_arguments(["chado", "import", "ontology", "-f", "testfile", "-A",
-                                            "testauthority", "-F", "owl", "testdb"])
-        tasks.run_import_command("ontology", args, self.uri)
+        args = ["chado", "import", "ontology", "-f", "testfile", "-A", "testauthority", "-F", "owl", "testdb"]
+        parsed_args = chado_tools.parse_arguments(args)
+        tasks.run_import_command(args[2], parsed_args, self.uri)
         mock_download.assert_not_called()
         mock_import.assert_called_with("testfile", "owl", "testauthority")
 
         mock_download.reset_mock()
         mock_download.return_value = "downloaded_file"
-        args = chado_tools.parse_arguments(["chado", "import", "ontology", "-u", "testurl", "-A",
-                                            "testauthority", "-F", "owl", "testdb"])
-        tasks.run_import_command("ontology", args, self.uri)
+        args = ["chado", "import", "ontology", "-u", "testurl", "-A", "testauthority", "-F", "owl", "testdb"]
+        parsed_args = chado_tools.parse_arguments(args)
+        tasks.run_import_command(args[2], parsed_args, self.uri)
         mock_download.assert_called_with("testurl")
         mock_import.assert_called_with("downloaded_file", "owl", "testauthority")
 

--- a/pychado/tests/tasks_tests.py
+++ b/pychado/tests/tasks_tests.py
@@ -1,5 +1,5 @@
 import unittest.mock
-from scripts import chado_tools
+from terminal import chado_tools
 from pychado import tasks, queries, dbutils, utils
 from pychado.io import load_ontology
 
@@ -115,24 +115,6 @@ class TestTasks(unittest.TestCase):
         tasks.run_command_with_arguments(args[1], args[2], parsed_args, self.uri)
         mock_create.assert_called_with(self.uri)
         mock_restore.assert_called_with(self.uri, "testarchive")
-
-    @unittest.mock.patch('pychado.dbutils.dump_users')
-    def test_dump_users(self, mock_dump):
-        # Checks that the function exporting a list of users is correctly called
-        self.assertIs(mock_dump, dbutils.dump_users)
-        args = ["chado", "admin", "dump_users", "testdb", "testfile"]
-        parsed_args = chado_tools.parse_arguments(args)
-        tasks.run_command_with_arguments(args[1], args[2], parsed_args, self.uri)
-        mock_dump.assert_called_with(self.uri, "testfile")
-
-    @unittest.mock.patch('pychado.dbutils.restore_users')
-    def test_restore_users(self, mock_restore):
-        # Checks that the function importing a list of users is correctly called
-        self.assertIs(mock_restore, dbutils.restore_users)
-        args = ["chado", "admin", "restore_users", "testdb", "testfile"]
-        parsed_args = chado_tools.parse_arguments(args)
-        tasks.run_command_with_arguments(args[1], args[2], parsed_args, self.uri)
-        mock_restore.assert_called_with(self.uri, "testfile")
 
     @unittest.mock.patch('pychado.utils.read_text')
     @unittest.mock.patch('pychado.dbutils.query_to_file')

--- a/scripts/chado_tools.py
+++ b/scripts/chado_tools.py
@@ -15,22 +15,22 @@ def main():
     arguments = parse_arguments(sys.argv)
     command = sys.argv[1]
     sub_command = ""
+    if command in wrapper_commands():
+        sub_command = sys.argv[2]
 
     if command in setup_commands():
-        # Set database connection parameters
-        pychado.tasks.run_command_with_arguments(command, sub_command, arguments, dict())
 
+        # Set database connection parameters
+        pychado.tasks.setup(command)
     else:
+
         # Check database access
         start_time = time.time()
-        connection_parameters = pychado.tasks.read_configuration_file(arguments.config)
-        if pychado.tasks.check_access(connection_parameters, arguments.dbname, command):
+        connection_string = pychado.tasks.create_connection_string(arguments.config, arguments.dbname)
+        if pychado.tasks.check_access(connection_string, sub_command):
 
             # Run the command
-            connection_parameters["database"] = arguments.dbname
-            if command not in general_commands():
-                sub_command = sys.argv[2]
-            pychado.tasks.run_command_with_arguments(command, sub_command, arguments, connection_parameters)
+            pychado.tasks.run_command_with_arguments(command, sub_command, arguments, connection_string)
 
         # Print run time
         if arguments.verbose:
@@ -49,9 +49,6 @@ def general_commands() -> dict:
     """Lists the available general sub-commands of the 'chado' command with corresponding descriptions"""
     return {
         "connect": "connect to a CHADO database for an interactive session",
-        "create": "create a new instance of the CHADO schema",
-        "dump": "dump a CHADO database into an archive file",
-        "restore": "restore a CHADO database from an archive file",
         "query": "query a CHADO database and export the result to a text file",
         "stats": "obtain statistics to updates in a CHADO database"
     }
@@ -63,7 +60,20 @@ def wrapper_commands() -> dict:
         "list": "list all entities of a specified type in the CHADO database",
         "insert": "insert a new entity of a specified type into the CHADO database",
         "delete": "delete an entity of a specified type from the CHADO database",
-        "import": "import entities of a specified type into the CHADO database"
+        "import": "import entities of a specified type into the CHADO database",
+        "admin": "perform administrative tasks, such as creating or dumping a CHADO database"
+    }
+
+
+def admin_commands() -> dict:
+    """Lists the available sub-commands of the 'chado admin' command with corresponding descriptions"""
+    return {
+        "create": "create a new instance of the CHADO schema",
+        "drop": "drop a CHADO database",
+        "dump": "dump a CHADO database into an archive file",
+        "restore": "restore a CHADO database from an archive file",
+        "dump_users": "export the list of users of a CHADO database to a file",
+        "restore_users": "import the list of users for a CHADO database from a file"
     }
 
 
@@ -149,12 +159,8 @@ def add_arguments_by_command(command: str, parser: argparse.ArgumentParser):
     """Defines formal arguments for a specified sub-command"""
     if command == "connect":
         pass
-    elif command == "create":
-        add_create_arguments(parser)
-    elif command == "dump":
-        add_dump_arguments(parser)
-    elif command == "restore":
-        add_restore_arguments(parser)
+    elif command == "admin":
+        add_admin_arguments(parser)
     elif command == "query":
         add_query_arguments(parser)
     elif command == "stats":
@@ -171,19 +177,58 @@ def add_arguments_by_command(command: str, parser: argparse.ArgumentParser):
         print("Command '" + parser.prog + "' is not available.")
 
 
+def add_admin_arguments(parser: argparse.ArgumentParser):
+    """Defines formal arguments for the 'chado admin' sub-command"""
+    parser.epilog = "For detailed usage information type '" + parser.prog + " <command> -h'"
+    subparsers = parser.add_subparsers()
+    for command, description in admin_commands().items():
+        # Create subparser and add general and specific formal arguments
+        sub = subparsers.add_parser(command, description=description, help=description)
+        add_general_arguments(sub)
+        add_admin_arguments_by_command(command, sub)
+
+
+def add_admin_arguments_by_command(command: str, parser: argparse.ArgumentParser):
+    """Defines formal arguments for a specified sub-command of 'chado admin'"""
+    if command == "create":
+        add_create_arguments(parser)
+    elif command == "drop":
+        pass
+    elif command == "dump":
+        add_dump_arguments(parser)
+    elif command == "restore":
+        add_restore_arguments(parser)
+    elif command == "dump_users":
+        add_dump_users_arguments(parser)
+    elif command == "restore_users":
+        add_restore_users_arguments(parser)
+    else:
+        print("Command '" + parser.prog + "' is not available.")
+
+
 def add_create_arguments(parser: argparse.ArgumentParser):
-    """Defines formal arguments for the 'chado create' sub-command"""
+    """Defines formal arguments for the 'chado admin create' sub-command"""
     parser.add_argument("-s", "--schema", default="", help="File with database schema (default: GMOD schema 1.31)")
 
 
 def add_dump_arguments(parser: argparse.ArgumentParser):
-    """Defines formal arguments for the 'chado dump' sub-command"""
+    """Defines formal arguments for the 'chado admin dump' sub-command"""
     parser.add_argument("archive", help="archive file to be created")
 
 
 def add_restore_arguments(parser: argparse.ArgumentParser):
-    """Defines formal arguments for the 'chado restore' sub-command"""
+    """Defines formal arguments for the 'chado admin restore' sub-command"""
     parser.add_argument("archive", help="archive file")
+
+
+def add_dump_users_arguments(parser: argparse.ArgumentParser):
+    """Defines formal arguments for the 'chado admin dump_users' sub-command"""
+    parser.add_argument("file", help="file to which users are exported")
+
+
+def add_restore_users_arguments(parser: argparse.ArgumentParser):
+    """Defines formal arguments for the 'chado admin restore_users' sub-command"""
+    parser.add_argument("file", help="file from which users are imported")
 
 
 def add_query_arguments(parser: argparse.ArgumentParser):

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 import setuptools
 import os
 
@@ -9,7 +11,7 @@ except FileNotFoundError or FileExistsError:
 
 setuptools.setup(
     name="chado-tools",
-    version="0.1.0",
+    version="0.1.1",
     author="Christoph Puethe",
     author_email="path-help@sanger.ac.uk",
     description="Tools to access CHADO databases",
@@ -28,7 +30,7 @@ setuptools.setup(
     },
     entry_points={
         "console_scripts": [
-            "chado = scripts.chado_tools:main",
+            "chado = terminal.chado_tools:main",
         ]
     },
     test_suite="nose.collector",

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,8 @@ setuptools.setup(
     ],
     install_requires=[
         "sqlalchemy",
-        "psycopg2",
+        "sqlalchemy-utils",
+        "psycopg2-binary",
         "pyyaml",
         "pronto"
     ],

--- a/terminal/chado_tools.py
+++ b/terminal/chado_tools.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 import sys
 import os
 import pkg_resources
@@ -71,9 +69,7 @@ def admin_commands() -> dict:
         "create": "create a new instance of the CHADO schema",
         "drop": "drop a CHADO database",
         "dump": "dump a CHADO database into an archive file",
-        "restore": "restore a CHADO database from an archive file",
-        "dump_users": "export the list of users of a CHADO database to a file",
-        "restore_users": "import the list of users for a CHADO database from a file"
+        "restore": "restore a CHADO database from an archive file"
     }
 
 
@@ -198,10 +194,6 @@ def add_admin_arguments_by_command(command: str, parser: argparse.ArgumentParser
         add_dump_arguments(parser)
     elif command == "restore":
         add_restore_arguments(parser)
-    elif command == "dump_users":
-        add_dump_users_arguments(parser)
-    elif command == "restore_users":
-        add_restore_users_arguments(parser)
     else:
         print("Command '" + parser.prog + "' is not available.")
 
@@ -219,16 +211,6 @@ def add_dump_arguments(parser: argparse.ArgumentParser):
 def add_restore_arguments(parser: argparse.ArgumentParser):
     """Defines formal arguments for the 'chado admin restore' sub-command"""
     parser.add_argument("archive", help="archive file")
-
-
-def add_dump_users_arguments(parser: argparse.ArgumentParser):
-    """Defines formal arguments for the 'chado admin dump_users' sub-command"""
-    parser.add_argument("file", help="file to which users are exported")
-
-
-def add_restore_users_arguments(parser: argparse.ArgumentParser):
-    """Defines formal arguments for the 'chado admin restore_users' sub-command"""
-    parser.add_argument("file", help="file from which users are imported")
 
 
 def add_query_arguments(parser: argparse.ArgumentParser):


### PR DESCRIPTION
- hide 'admin' commands (create, drop, dump, restore) behind 'chado admin'
- use sqlalchemy-utils library for create, drop, exists
- remove some code duplification and unused functions, simplify "tasks"
- drop database only after confirmation by the user
- add unit test for dropping a database
- minor corrections