### PR TITLE
GFF loader

### DIFF
--- a/pychado/chado_tools.py
+++ b/pychado/chado_tools.py
@@ -102,7 +102,9 @@ def delete_commands() -> dict:
 def import_commands() -> dict:
     """Lists the available sub-commands of the 'chado import' command with corresponding descriptions"""
     return {
-        "ontology": "import an ontology into the CHADO database"
+        "essentials": "import basic terms into the CHADO database (for setup)",
+        "ontology": "import an ontology into the CHADO database",
+        "gff": "import genomic data from a GFF3 file into the CHADO database"
     }
 
 
@@ -314,9 +316,9 @@ def add_insert_organism_arguments(parser: argparse.ArgumentParser):
     """Defines formal arguments for the 'chado insert organism' sub-command"""
     parser.add_argument("-g", "--genus", required=True, help="genus of the organism")
     parser.add_argument("-s", "--species", required=True, help="species of the organism")
+    parser.add_argument("-i", "--infraspecific_name", help="infraspecific name (strain) of the organism")
     parser.add_argument("-a", "--abbreviation", required=True, help="abbreviation/short name of the organism")
     parser.add_argument("--common_name", help="common name of the organism (default: use abbreviation, if provided)")
-    parser.add_argument("--infraspecific_name", help="infraspecific name of the organism")
     parser.add_argument("--comment", help="comment")
 
 
@@ -358,8 +360,12 @@ def add_import_arguments(parser: argparse.ArgumentParser):
 
 def add_import_arguments_by_command(command: str, parser: argparse.ArgumentParser):
     """Defines formal arguments for a specified sub-command of 'chado import'"""
-    if command == "ontology":
+    if command == "essentials":
+        pass
+    elif command == "ontology":
         add_import_ontology_arguments(parser)
+    elif command == "gff":
+        add_import_gff_arguments(parser)
     else:
         print("Command '" + parser.prog + "' is not available.")
 
@@ -373,3 +379,10 @@ def add_import_ontology_arguments(parser: argparse.ArgumentParser):
                         help="database authority of the terms in the file, e.g. 'GO'")
     parser.add_argument("-F", "--format", default="obo", choices={"obo", "owl"},
                         help="format of the file (default: obo)")
+
+
+def add_import_gff_arguments(parser: argparse.ArgumentParser):
+    """Defines formal arguments for the 'chado import gff' sub-command"""
+    parser.add_argument("-f", "--input_file", required=True, help="GFF3 input file")
+    parser.add_argument("-a", "--abbreviation", required=True, dest="organism",
+                        help="abbreviation/short name of the organism")

--- a/pychado/ddl.py
+++ b/pychado/ddl.py
@@ -5,7 +5,7 @@ import sqlalchemy.engine
 import sqlalchemy.schema
 import sqlalchemy.event
 from . import utils
-from .orm import base, general, cv, organism, pub, sequence, audit
+from .orm import base, general, cv, organism, pub, sequence, companalysis, audit
 
 
 class ChadoClient(object):
@@ -218,7 +218,7 @@ class PublicSchemaSetupClient(SchemaSetupClient):
     def __init__(self, uri: str):
         """Constructor"""
         super().__init__(uri)
-        self.modules = [general, cv, organism, pub, sequence]
+        self.modules = [general, cv, organism, pub, sequence, companalysis]
 
 
 class AuditSchemaSetupClient(SchemaSetupClient):

--- a/pychado/io/essentials.py
+++ b/pychado/io/essentials.py
@@ -1,0 +1,134 @@
+from ..io import iobase
+from ..orm import general, cv, pub
+
+
+class EssentialsClient(iobase.ImportClient):
+    """Class for importing essential basic entries into the Chado tables"""
+    
+    def load(self):
+        """Import essential basic entries into various database tables"""
+        self._load_generic_entries()
+        self._load_relationship_entries()
+        self._load_synonymtype_entries()
+        self._load_cvterm_property_type_entries()
+        self._load_feature_property_entries()
+        self._load_genedb_synonymtype_entries()
+        self.session.commit()
+
+    def _load_generic_entries(self):
+        """Import generic entries in the db, dbxref, cv, cvterm, and pub tables"""
+        new_generic_db = general.Db(name="null", description="a fake database for locally created essentials")
+        generic_db = self._handle_db(new_generic_db)
+        new_generic_dbxref = general.DbxRef(db_id=generic_db.db_id, accession="null")
+        generic_dbxref = self._handle_dbxref(new_generic_dbxref, generic_db.name)
+        new_generic_cv = cv.Cv(name="null", definition="a fake vocabulary for locally created essentials")
+        generic_cv = self._handle_cv(new_generic_cv)
+        new_generic_cvterm = cv.CvTerm(cv_id=generic_cv.cv_id, dbxref_id=generic_dbxref.dbxref_id, name="null")
+        generic_cvterm = self._handle_cvterm(new_generic_cvterm, generic_cv.name)
+        new_generic_pub = pub.Pub(uniquename="null", type_id=generic_cvterm.cvterm_id)
+        self._handle_pub(new_generic_pub)
+
+    def _load_relationship_entries(self, *further_terms):
+        """Import CV terms for relationships
+        (note: all other basic relationship terms are part of the RO relationship ontology)"""
+        new_relationship_db = general.Db(name="RO")
+        relationship_db = self._handle_db(new_relationship_db)
+        new_relationship_cv = cv.Cv(name="relationship")
+        relationship_cv = self._handle_cv(new_relationship_cv)
+
+        terms = ["is_a"] + [term for term in further_terms]
+        for term in terms:
+
+            new_dbxref = general.DbxRef(db_id=relationship_db.db_id, accession=term)
+            dbxref = self._handle_dbxref(new_dbxref, relationship_db.name)
+            new_cvterm = cv.CvTerm(cv_id=relationship_cv.cv_id, dbxref_id=dbxref.dbxref_id, name=term,
+                                   is_relationshiptype=1)
+            self._handle_cvterm(new_cvterm, relationship_cv.name)
+
+    def _load_synonymtype_entries(self):
+        """Import CV terms for synonym types"""
+        new_synonymtype_db = general.Db(name="internal")
+        synonymtype_db = self._handle_db(new_synonymtype_db)
+        new_synonymtype_cv = cv.Cv(name="synonym_type")
+        synonymtype_cv = self._handle_cv(new_synonymtype_cv)
+
+        for term in ["exact", "narrow", "broad", "related"]:
+
+            new_dbxref = general.DbxRef(db_id=synonymtype_db.db_id, accession=term)
+            dbxref = self._handle_dbxref(new_dbxref, synonymtype_db.name)
+            new_cvterm = cv.CvTerm(cv_id=synonymtype_cv.cv_id, dbxref_id=dbxref.dbxref_id, name=term)
+            self._handle_cvterm(new_cvterm, synonymtype_cv.name)
+
+    def _load_cvterm_property_type_entries(self):
+        """Import CV terms for property types"""
+        new_propertytype_db = general.Db(name="internal")
+        propertytype_db = self._handle_db(new_propertytype_db)
+        new_propertytype_cv = cv.Cv(name="cvterm_property_type")
+        propertytype_cv = self._handle_cv(new_propertytype_cv)
+
+        # non-relationship types
+        for term in ["comment", "is_anonymous", "is_transitive", "is_anti_symmetric", "is_reflexive", "is_symmetric",
+                     "is_cyclic"]:
+
+            new_dbxref = general.DbxRef(db_id=propertytype_db.db_id, accession=term)
+            dbxref = self._handle_dbxref(new_dbxref, propertytype_db.name)
+            new_cvterm = cv.CvTerm(cv_id=propertytype_cv.cv_id, dbxref_id=dbxref.dbxref_id, name=term)
+            self._handle_cvterm(new_cvterm, propertytype_cv.name)
+
+        # relationship types
+        for term in ["intersection_of", "disjoint_from"]:
+
+            new_dbxref = general.DbxRef(db_id=propertytype_db.db_id, accession=term)
+            dbxref = self._handle_dbxref(new_dbxref, propertytype_db.name)
+            new_cvterm = cv.CvTerm(cv_id=propertytype_cv.cv_id, dbxref_id=dbxref.dbxref_id, name=term,
+                                   is_relationshiptype=1)
+            self._handle_cvterm(new_cvterm, propertytype_cv.name)
+
+    def _load_feature_property_entries(self):
+        """Import CV terms for feature properties (note: these terms are also part of the SOFP ontology)"""
+        new_feature_property_db = general.Db(name="SOFP")
+        feature_property_db = self._handle_db(new_feature_property_db)
+        new_feature_property_cv = cv.Cv(name="feature_property")
+        feature_property_cv = self._handle_cv(new_feature_property_cv)
+
+        for term in ["comment", "score", "source", "description"]:
+
+            new_dbxref = general.DbxRef(db_id=feature_property_db.db_id, accession=term)
+            dbxref = self._handle_dbxref(new_dbxref, feature_property_db.name)
+            new_cvterm = cv.CvTerm(cv_id=feature_property_cv.cv_id, dbxref_id=dbxref.dbxref_id, name=term)
+            self._handle_cvterm(new_cvterm, feature_property_cv.name)
+
+    def _load_genedb_synonymtype_entries(self):
+        """Import CV terms for specific GeneDB synonym types"""
+        new_synonymtype_db = general.Db(name="genedb_misc")
+        synonymtype_db = self._handle_db(new_synonymtype_db)
+        new_synonymtype_cv = cv.Cv(name="genedb_synonym_type")
+        synonymtype_cv = self._handle_cv(new_synonymtype_cv)
+
+        for term in ["synonym", "alias", "systematic_id", "previous_systematic_id", "temporary_systematic_id"]:
+
+            new_dbxref = general.DbxRef(db_id=synonymtype_db.db_id, accession=term)
+            dbxref = self._handle_dbxref(new_dbxref, synonymtype_db.name)
+            new_cvterm = cv.CvTerm(cv_id=synonymtype_cv.cv_id, dbxref_id=dbxref.dbxref_id, name=term)
+            self._handle_cvterm(new_cvterm, synonymtype_cv.name)
+
+    def _load_sequence_type_entries(self):
+        """Import CV terms for sequence types; for testing only (all terms are part of the SO sequence ontology)"""
+        new_sequence_db = general.Db(name="SO")
+        sequence_db = self._handle_db(new_sequence_db)
+        new_sequence_cv = cv.Cv(name="sequence")
+        sequence_cv = self._handle_cv(new_sequence_cv)
+
+        for term in ["gene", "intron", "exon", "CDS", "mRNA", "chromosome"]:
+
+            new_dbxref = general.DbxRef(db_id=sequence_db.db_id, accession=term)
+            dbxref = self._handle_dbxref(new_dbxref, sequence_db.name)
+            new_cvterm = cv.CvTerm(cv_id=sequence_cv.cv_id, dbxref_id=dbxref.dbxref_id, name=term)
+            self._handle_cvterm(new_cvterm, sequence_cv.name)
+
+        self.session.commit()
+
+    def _load_further_relationship_entries(self):
+        """Import further CV terms for relationships; for testing only"""
+        self._load_relationship_entries("part_of", "derives_from")
+        self.session.commit()

--- a/pychado/io/gff.py
+++ b/pychado/io/gff.py
@@ -1,0 +1,458 @@
+import os
+from typing import List, Dict, Union
+import gffutils
+from . import iobase, ontology
+from ..orm import general, cv, organism, pub, sequence
+
+
+class GFFImportClient(iobase.ImportClient):
+    """Class for importing genomic data from GFF files into Chado and vice versa"""
+
+    def __init__(self, uri: str, verbose=False):
+        """Constructor"""
+
+        # Connect to database
+        super().__init__(uri, verbose)
+
+        # Create array for temporary SQLite databases
+        self._sqlite_databases = []
+
+        # Load essentials
+        self._synonym_terms = self._load_cvterms("genedb_synonym_type", ["synonym", "previous_systematic_id"])
+        self._relationship_terms = self._load_cvterms("relationship", ["is_a", "part_of", "derives_from"], True)
+        self._feature_property_terms = self._load_cvterms("feature_property", ["score", "source", "description",
+                                                                               "comment"])
+        self._sequence_terms = self._load_cvterms("sequence", ["gene", "intron", "exon", "CDS", "mRNA", "chromosome"])
+        self._default_pub = self._load_pub("null")
+
+    def __del__(self):
+        """Destructor"""
+
+        # Disconnect from database
+        super().__del__()
+
+        # Delete temporary SQLite database
+        for database in self._sqlite_databases:
+            if os.path.exists(database):
+                os.remove(database)
+
+    def load(self, filename: str, organism_name: str):
+        """Import data from a GFF3 file into a Chado database"""
+
+        # Create temporary SQLite database
+        gff_db = self._create_sqlite_db(filename)
+
+        # Load dependencies
+        default_organism = self._load_organism(organism_name)
+
+        # Initiate global containers
+        all_feature_entries = {}
+
+        # Loop over all entries in the gff file
+        for gff_feature in gff_db.all_features():
+
+            # Insert or update entries in various tables
+            feature_entry = self._handle_child_feature(gff_feature, default_organism)
+            if feature_entry:
+                self._handle_location(gff_feature, feature_entry)
+                self._handle_synonyms(gff_feature, feature_entry)
+                self._handle_properties(gff_feature, feature_entry)
+                self._handle_cross_references(gff_feature, feature_entry)
+                self._handle_ontology_terms(gff_feature, feature_entry)
+                self._handle_publications(gff_feature, feature_entry)
+
+                # Save feature entry in global array
+                all_feature_entries[feature_entry.uniquename] = feature_entry
+
+        # Second loop over all entries in the gff file
+        for gff_feature in gff_db.all_features():
+
+            # Insert or update entries in various tables
+            self._handle_relationships(gff_feature, all_feature_entries)
+
+        # Commit changes
+        self.session.commit()
+
+    def _create_sqlite_db(self, filename: str) -> gffutils.FeatureDB:
+        """Creates a local SQLite database containing data from a GFF file"""
+        database_name = os.getcwd() + "/" + filename + ".sqlitedb"
+        self._sqlite_databases.append(database_name)
+        gffutils.create_db(filename, database_name, force=True, keep_order=True)
+        database = gffutils.FeatureDB(database_name)
+        return database
+
+    def _handle_child_feature(self, gff_feature: gffutils.Feature, organism_entry: organism.Organism
+                              ) -> Union[None, sequence.Feature]:
+        """Inserts or updates an entry in the 'feature' table and returns it"""
+
+        # Check if all dependencies are met
+        if gff_feature.featuretype not in self._sequence_terms:
+            self.printer.print("WARNING: Sequence type '" + gff_feature.featuretype + "' not present in database")
+            return None
+        type_entry = self._sequence_terms[gff_feature.featuretype]
+
+        # Create a feature object, and update the corresponding table
+        new_feature_entry = self._create_feature(gff_feature, organism_entry.organism_id, type_entry.cvterm_id)
+        feature_entry = self._handle_feature(new_feature_entry, organism_entry.abbreviation)
+        return feature_entry
+
+    def _handle_location(self, gff_feature: gffutils.Feature, feature_entry: sequence.Feature
+                         ) -> Union[None, sequence.FeatureLoc]:
+        """Inserts or updates an entry in the 'featureloc' table and returns it"""
+
+        # Get entry from 'srcfeature' table
+        srcfeature_entry = self.query_first(sequence.Feature, organism_id=feature_entry.organism_id,
+                                            uniquename=gff_feature.seqid)
+        if not srcfeature_entry:
+            self.printer.print("WARNING: Parent sequence '" + gff_feature.seqid + "' not present in database")
+            return None
+
+        # Insert/update entry in the 'featureloc' table
+        new_featureloc_entry = self._create_featureloc(gff_feature, feature_entry.feature_id,
+                                                       srcfeature_entry.feature_id)
+        featureloc_entry = self._handle_featureloc(new_featureloc_entry, feature_entry.uniquename)
+        return featureloc_entry
+
+    def _handle_synonyms(self, gff_feature: gffutils.Feature,
+                         feature_entry: sequence.Feature) -> List[sequence.FeatureSynonym]:
+        """Inserts or updates entries in the 'synonym' and 'feature_synonym' tables and returns the latter"""
+
+        # Extract existing synonyms for this feature from the database
+        existing_feature_synonyms = self.query_all(sequence.FeatureSynonym, feature_id=feature_entry.feature_id)
+        all_feature_synonyms = []
+
+        # Loop over all synonyms for this feature in the GFF file
+        synonyms = self._extract_synonyms(gff_feature)
+        for synonym_type, aliases in synonyms.items():
+
+            # Get database entry for synonym type
+            if synonym_type not in self._synonym_terms:
+                self.printer.print("WARNING: Synonym type '" + synonym_type + "' not present in database.")
+                continue
+            type_entry = self._synonym_terms[synonym_type]
+
+            for alias in aliases:
+
+                # Insert/update entry in the 'synonym' table
+                new_synonym_entry = sequence.Synonym(name=alias, type_id=type_entry.cvterm_id, synonym_sgml=alias)
+                synonym_entry = self._handle_synonym(new_synonym_entry)
+
+                # Insert/update entry in the 'feature_synonym' table
+                new_feature_synonym_entry = sequence.FeatureSynonym(
+                    synonym_id=synonym_entry.synonym_id, feature_id=feature_entry.feature_id,
+                    pub_id=self._default_pub.pub_id, is_current=(synonym_type != "previous_systematic_id"))
+                feature_synonym_entry = self._handle_feature_synonym(new_feature_synonym_entry,
+                                                                     existing_feature_synonyms)
+                all_feature_synonyms.append(feature_synonym_entry)
+
+        return all_feature_synonyms
+
+    def _handle_publications(self, gff_feature: gffutils.Feature, feature_entry: sequence.Feature
+                             ) -> List[sequence.FeaturePub]:
+        """Inserts or updates entries in the 'pub' and 'feature_pub' tables and returns the latter"""
+
+        # Extract existing publications for this feature from the database
+        existing_feature_pubs = self.query_all(sequence.FeaturePub, feature_id=feature_entry.feature_id)
+        all_feature_pubs = []
+
+        # Loop over all publications for this feature in the GFF file
+        publications = self._extract_publications(gff_feature)
+        for publication in publications:
+
+            # Insert/update entry in the 'pub' table
+            new_pub_entry = pub.Pub(uniquename=publication, type_id=self._default_pub.type_id)
+            pub_entry = self._handle_pub(new_pub_entry)
+
+            # Insert/update entry in the 'feature_pub' table
+            new_feature_pub_entry = sequence.FeaturePub(feature_id=feature_entry.feature_id, pub_id=pub_entry.pub_id)
+            feature_pub_entry = self._handle_feature_pub(new_feature_pub_entry, existing_feature_pubs,
+                                                         feature_entry.uniquename, pub_entry.uniquename)
+            all_feature_pubs.append(feature_pub_entry)
+
+        return all_feature_pubs
+
+    def _handle_relationships(self, gff_feature: gffutils.Feature, all_features: Dict[str, sequence.Feature]
+                              ) -> List[sequence.FeatureRelationship]:
+        """Inserts or updates entries in the 'feature_relationship' table and returns them"""
+
+        # Get database entry for relationship subject from array
+        if gff_feature.id not in all_features:
+            self.printer.print("WARNING: Feature '" + gff_feature.id + "' not present in input file.")
+            return []
+        subject_entry = all_features[gff_feature.id]
+
+        # Extract existing relationships for this subject from the database
+        existing_feature_relationships = self.query_all(sequence.FeatureRelationship,
+                                                        subject_id=subject_entry.feature_id)
+        all_feature_relationships = []
+
+        # Loop over all relationships for this feature in the GFF file
+        relationships = self._extract_relationships(gff_feature)
+        for relationship, parents in relationships.items():
+
+            # Get database entry for relationship type
+            if relationship not in self._relationship_terms:
+                self.printer.print("WARNING: Relationship '" + relationship + "' not present in database.")
+                continue
+            type_entry = self._relationship_terms[relationship]
+
+            for parent in parents:
+
+                # Get database entry for object
+                if parent not in all_features:
+                    self.printer.print("WARNING: Feature '" + parent + "' not present in input file.")
+                    continue
+                object_entry = all_features[parent]
+
+                # Insert/update entry in the 'feature_relationship' table
+                new_relationship_entry = sequence.FeatureRelationship(subject_id=subject_entry.feature_id,
+                                                                      object_id=object_entry.feature_id,
+                                                                      type_id=type_entry.cvterm_id)
+                feature_relationship_entry = self._handle_feature_relationship(
+                    new_relationship_entry, existing_feature_relationships, subject_entry.uniquename,
+                    object_entry.uniquename, type_entry.name)
+                all_feature_relationships.append(feature_relationship_entry)
+
+        return all_feature_relationships
+
+    def _handle_properties(self, gff_feature: gffutils.Feature, feature_entry: sequence.Feature
+                           ) -> List[sequence.FeatureProp]:
+        """Inserts or updates entries in the 'featureprop' table and returns them"""
+
+        # Extract existing properties for this feature from the database
+        existing_featureprops = self.query_all(sequence.FeatureProp, feature_id=feature_entry.feature_id)
+        all_featureprops = []
+
+        # Loop over all properties of this feature in the GFF file
+        props = self._extract_properties(gff_feature)
+        for prop, values in props.items():
+            for value in values:
+
+                # Get database entry for property type from array
+                if prop not in self._feature_property_terms:
+                    self.printer.print("WARNING: Feature property term '" + prop + "' not present in input file.")
+                    continue
+                type_entry = self._feature_property_terms[prop]
+
+                # Insert/update entry in the 'feature_relationship' table
+                new_featureprop_entry = sequence.FeatureProp(feature_id=feature_entry.feature_id,
+                                                             type_id=type_entry.cvterm_id, value=value)
+                featureprop_entry = self._handle_featureprop(new_featureprop_entry, existing_featureprops, prop, value,
+                                                             feature_entry.uniquename)
+                all_featureprops.append(featureprop_entry)
+
+        return all_featureprops
+
+    def _handle_cross_references(self, gff_feature: gffutils.Feature, feature_entry: sequence.Feature
+                                 ) -> List[sequence.FeatureDbxRef]:
+        """Inserts or updates entries in the 'feature_dbxref' table and returns them"""
+
+        # Extract existing cross references for this feature from the database
+        existing_feature_dbxrefs = self.query_all(sequence.FeatureDbxRef, feature_id=feature_entry.feature_id)
+        all_feature_dbxrefs = []
+
+        # Loop over all cross references of this feature in the GFF file
+        crossrefs = self._extract_crossrefs(gff_feature)
+        for crossref in crossrefs:
+
+            # Split database cross reference (dbxref) into db, accession, version
+            (db_authority, accession, version) = ontology.split_dbxref(crossref)
+
+            # Insert/update entry in the 'db' table
+            new_db_entry = general.Db(name=db_authority)
+            db_entry = self._handle_db(new_db_entry)
+
+            # Insert/update entry in the 'dbxref' table
+            new_dbxref_entry = general.DbxRef(db_id=db_entry.db_id, accession=accession, version=version)
+            dbxref_entry = self._handle_dbxref(new_dbxref_entry, db_authority)
+
+            # Insert/update entry in the 'feature_dbxref' table
+            new_feature_dbxref_entry = sequence.FeatureDbxRef(feature_id=feature_entry.feature_id,
+                                                              dbxref_id=dbxref_entry.dbxref_id)
+            feature_dbxref_entry = self._handle_feature_dbxref(new_feature_dbxref_entry, existing_feature_dbxrefs,
+                                                               crossref, feature_entry.uniquename)
+            all_feature_dbxrefs.append(feature_dbxref_entry)
+
+        return all_feature_dbxrefs
+
+    def _handle_ontology_terms(self, gff_feature: gffutils.Feature, feature_entry: sequence.Feature
+                               ) -> List[sequence.FeatureCvTerm]:
+        """Inserts or updates entries in the 'feature_cvterm' table and returns them"""
+
+        # Extract existing ontology terms for this feature from the database
+        existing_feature_cvterms = self.query_all(sequence.FeatureCvTerm, feature_id=feature_entry.feature_id)
+        all_feature_cvterms = []
+
+        ontology_terms = self._extract_ontology_terms(gff_feature)
+        for ontology_term in ontology_terms:
+
+            # Split database cross reference (dbxref) into db, accession, version
+            (db_authority, accession, version) = ontology.split_dbxref(ontology_term)
+
+            # Get entry from 'db' table
+            db_entry = self.query_first(general.Db, name=db_authority)
+            if not db_entry:
+                self.printer.print("WARNING: Ontology '" + db_authority + "' not present in database.")
+                continue
+
+            # Get entry from 'dbxref' table
+            dbxref_entry = self.query_first(general.DbxRef, db_id=db_entry.db_id, accession=accession)
+            if not dbxref_entry:
+                self.printer.print("WARNING: Ontology term '" + ontology_term + "' not present in database.")
+                continue
+
+            # Get entry from 'cvterm' table
+            cvterm_entry = self.query_first(cv.CvTerm, dbxref_id=dbxref_entry.dbxref_id)
+            if not cvterm_entry:
+                self.printer.print("WARNING: CV term for ontology term '" + ontology_term
+                                   + "' not present in database.")
+                continue
+
+            # Insert/update entry in the 'feature_cvterm' table
+            new_feature_cvterm_entry = sequence.FeatureCvTerm(feature_id=feature_entry.feature_id,
+                                                              cvterm_id=cvterm_entry.cvterm_id,
+                                                              pub_id=self._default_pub.pub_id)
+            feature_cvterm_entry = self._handle_feature_cvterm(new_feature_cvterm_entry, existing_feature_cvterms,
+                                                               ontology_term, feature_entry.uniquename)
+            all_feature_cvterms.append(feature_cvterm_entry)
+
+        return all_feature_cvterms
+
+    def _create_feature(self, gff_feature: gffutils.Feature, organism_id: int, type_id: int) -> sequence.Feature:
+        """Creates a feature object from a GFF file entry"""
+        name = self._extract_name(gff_feature)
+        residues = self._extract_residues(gff_feature)
+        seqlen = None
+        if residues is not None:
+            seqlen = len(residues)
+        return sequence.Feature(organism_id=organism_id, type_id=type_id, uniquename=gff_feature.id, name=name,
+                                residues=residues, seqlen=seqlen)
+
+    @staticmethod
+    def _create_featureloc(gff_feature: gffutils.Feature, feature_id: int, srcfeature_id: int) -> sequence.FeatureLoc:
+        """Creates a featureloc object from a GFF file entry
+        coordinates are converted from base-oriented (1-based) to interbase (0-based)"""
+        return sequence.FeatureLoc(
+            feature_id=feature_id, srcfeature_id=srcfeature_id, fmin=gff_feature.start - 1, fmax=gff_feature.end,
+            strand=convert_strand(gff_feature.strand), phase=convert_frame(gff_feature.frame))
+
+    @staticmethod
+    def _extract_crossrefs(gff_feature: gffutils.Feature) -> List[str]:
+        """Extract database cross references from a GFF file entry"""
+        crossrefs = []
+        for key, value in gff_feature.attributes.items():
+            if key.lower() == "dbxref":
+                if isinstance(value, str):
+                    crossrefs.append(value)
+                elif isinstance(value, list):
+                    crossrefs.extend(value)
+        return crossrefs
+
+    @staticmethod
+    def _extract_ontology_terms(gff_feature: gffutils.Feature) -> List[str]:
+        """Extract cross references to ontology terms from a GFF file entry"""
+        ontology_terms = []
+        if "Ontology_term" in gff_feature.attributes:
+            ontology_terms = gff_feature.attributes["Ontology_term"]
+            if isinstance(ontology_terms, str):
+                ontology_terms = [ontology_terms]
+        return ontology_terms
+
+    @staticmethod
+    def _extract_properties(gff_feature: gffutils.Feature) -> Dict[str, List[str]]:
+        """Extracts properties from a GFF file entry
+        Properties are the 'score' and the 'source' as well as the attributes 'Note', 'description', 'comment'"""
+        gff_to_chado_key = {"Note": "comment", "comment": "comment", "description": "description"}
+        properties = {}
+        if gff_feature.score and gff_feature.score != '.':
+            properties["score"] = [gff_feature.score]
+        if gff_feature.source and gff_feature.source != '.':
+            properties["source"] = [gff_feature.source]
+        for gff_key, value in gff_feature.attributes.items():
+            if gff_key in gff_to_chado_key.keys():
+                chado_key = gff_to_chado_key[gff_key]
+                if isinstance(value, str):
+                    properties[chado_key] = [value]
+                elif isinstance(value, list):
+                    properties[chado_key] = value
+        return properties
+
+    @staticmethod
+    def _extract_relationships(gff_feature: gffutils.Feature) -> Dict[str, List[str]]:
+        """Extracts the relationships to other features from a GFF file entry"""
+        gff_to_chado_key = {"Parent": "part_of", "Derives_from": "derives_from"}
+        relationships = {}
+        for gff_key, value in gff_feature.attributes.items():
+            if gff_key in gff_to_chado_key.keys():
+                chado_key = gff_to_chado_key[gff_key]
+                if isinstance(value, str):
+                    relationships[chado_key] = [value]
+                elif isinstance(value, list):
+                    relationships[chado_key] = value
+        return relationships
+
+    @staticmethod
+    def _extract_synonyms(gff_feature: gffutils.Feature) -> Dict[str, List[str]]:
+        """Extracts synonyms/alias names from a GFF file entry"""
+        aliases = {}
+        for key, value in gff_feature.attributes.items():
+            if key.lower() in ["alias", "synonym", "previous_systematic_id"]:
+                if isinstance(value, str):
+                    aliases[key.lower()] = [value]
+                elif isinstance(value, list):
+                    aliases[key.lower()] = value
+        return aliases
+
+    @staticmethod
+    def _extract_name(gff_feature: gffutils.Feature) -> Union[None, str]:
+        """Extracts the feature name from a GFF file entry"""
+        name = None
+        if "Name" in gff_feature.attributes:
+            name = gff_feature.attributes["Name"]
+            if isinstance(name, list):
+                name = name[0]
+        return name
+
+    @staticmethod
+    def _extract_residues(gff_feature: gffutils.Feature) -> Union[None, str]:
+        """Extracts the sequence of amino acids from a GFF file entry representing a polypeptide"""
+        residues = None
+        if "translation" in gff_feature.attributes:
+            residues = gff_feature.attributes["translation"]
+            if isinstance(residues, str):
+                residues = residues.upper()
+            elif isinstance(residues, list):
+                residues = residues[0].upper()
+        return residues
+
+    @staticmethod
+    def _extract_publications(gff_feature: gffutils.Feature) -> List[str]:
+        """Extracts publications names from a GFF file entry"""
+        publications = []
+        if "literature" in gff_feature.attributes:
+            publications = gff_feature.attributes["literature"]
+            if isinstance(publications, str):
+                publications = [publications]
+        return publications
+
+
+def convert_strand(strand: str) -> Union[None, int]:
+    """Converts the strand from string notation to integer notation"""
+    if strand == '+':
+        return 1
+    elif strand == '-':
+        return -1
+    else:
+        return None
+
+
+def convert_frame(frame: str) -> Union[None, int]:
+    """Converts the frame from string notation to integer notation"""
+    try:
+        phase = int(frame)
+    except ValueError:
+        return None
+    if phase in [0, 1, 2]:
+        return phase
+    else:
+        return None

--- a/pychado/io/iobase.py
+++ b/pychado/io/iobase.py
@@ -1,5 +1,7 @@
+from typing import List, Dict
 import sqlalchemy.orm
-from .. import ddl
+from .. import utils, ddl
+from ..orm import general, cv, pub, organism, sequence
 
 
 class DatabaseError(Exception):
@@ -31,6 +33,14 @@ class IOClient(ddl.ChadoClient):
             query = query.filter_by(**kwargs)
         return query
 
+    def query_all(self, table, **kwargs):
+        """Helper class querying a table and returning all results"""
+        return self.query_table(table, **kwargs).all()
+
+    def query_first(self, table, **kwargs):
+        """Helper class querying a table and returning the first result"""
+        return self.query_table(table, **kwargs).first()
+
     def add_and_flush(self, obj):
         """Adds an entry to a database table"""
         self.session.add(obj)
@@ -44,7 +54,391 @@ class IOClient(ddl.ChadoClient):
 
     def find_or_insert(self, table, **kwargs):
         """Returns one entry of a database table matching a query. If no matching entry exists, it is created."""
-        entry = self.query_table(table, **kwargs).first()
+        entry = self.query_first(table, **kwargs)
         if not entry:
             entry = self.insert_into_table(table, **kwargs)
         return entry
+
+
+class ImportClient(IOClient):
+    """Base class for importing data into a CHADO database"""
+    
+    def __init__(self, uri: str, verbose=False):
+        """Constructor"""
+
+        # Connect to database
+        super().__init__(uri)
+
+        # Set up printer
+        self.printer = utils.VerbosePrinter(verbose)
+        
+    def _load_cvterm(self, term: str) -> cv.CvTerm:
+        """Loads a specific CV term"""
+        cvterm_entry = self.query_first(cv.CvTerm, name=term)
+        if not cvterm_entry:
+            raise DatabaseError("CV term '" + term + "' not present in database")
+        return cvterm_entry
+
+    def _load_cvterms(self, vocabulary: str, terms: List[str], relationship=False) -> Dict[str, cv.CvTerm]:
+        """Loads CV terms from a given vocabulary and returns them in a dictionary, keyed by name"""
+        cv_entry = self.query_first(cv.Cv, name=vocabulary)
+        if not cv_entry:
+            raise DatabaseError("CV '" + vocabulary + "' not present in database")
+        cvterm_entries = self.query_all(cv.CvTerm, cv_id=cv_entry.cv_id, is_relationshiptype=int(relationship))
+        cvterm_entries_dict = utils.list_to_dict(cvterm_entries, "name")
+        for term in terms:
+            if term not in cvterm_entries_dict:
+                raise DatabaseError("CV term '" + term + "' not present in database")
+        return cvterm_entries_dict
+
+    def _load_pub(self, pub_name: str) -> pub.Pub:
+        """Loads a pub entry from the database"""
+        pub_entry = self.query_first(pub.Pub, uniquename=pub_name)
+        if not pub_entry:
+            raise DatabaseError("Pub '" + pub_name + "' not present in database")
+        return pub_entry
+
+    def _load_organism(self, organism_name: str) -> organism.Organism:
+        """Loads an organism entry from the database"""
+        organism_entry = self.query_first(organism.Organism, abbreviation=organism_name)
+        if not organism_entry:
+            raise DatabaseError("Organism '" + organism_name + "' not present in database")
+        return organism_entry
+
+    def _handle_db(self, new_entry: general.Db) -> general.Db:
+        """Inserts or updates an entry in the 'db' table, and returns it"""
+
+        # Check if the db is already present in the database
+        existing_entry = self.query_first(general.Db, name=new_entry.name)
+        if existing_entry:
+
+            # Nothing to update, return existing entry
+            return existing_entry
+        else:
+
+            # Insert new db entry
+            self.add_and_flush(new_entry)
+            self.printer.print("Inserted db '" + new_entry.name + "'")
+            return new_entry
+
+    def _handle_dbxref(self, new_entry: general.DbxRef, db_authority="") -> general.DbxRef:
+        """Inserts or updates an entry in the 'dbxref' table, and returns it"""
+
+        # Check if the dbxref is already present in the database
+        existing_entry = self.query_first(general.DbxRef, db_id=new_entry.db_id, accession=new_entry.accession)
+        if existing_entry:
+
+            # Nothing to update, return existing entry
+            return existing_entry
+        else:
+
+            # Insert new db entry
+            self.add_and_flush(new_entry)
+            self.printer.print("Inserted dbxref '" + db_authority + "." + new_entry.accession + "'")
+            return new_entry
+
+    def _handle_cv(self, new_entry: cv.Cv) -> cv.Cv:
+        """Inserts or updates an entry in the 'cv' table, and returns it"""
+
+        # Check if the cv is already present in the database
+        existing_entry = self.query_first(cv.Cv, name=new_entry.name)
+        if existing_entry:
+
+            # Nothing to update, return existing entry
+            return existing_entry
+        else:
+
+            # Insert new cv entry
+            self.add_and_flush(new_entry)
+            self.printer.print("Inserted controlled vocabulary '" + new_entry.name + "'")
+            return new_entry
+
+    def _handle_cvterm(self, new_entry: cv.CvTerm, vocabulary="") -> cv.CvTerm:
+        """Inserts or updates an entry in the 'cvterm' table, and returns it"""
+
+        # Check if the cvterm is already present in the database (look for dbxref)
+        existing_entry = self.query_first(cv.CvTerm, dbxref_id=new_entry.dbxref_id)
+        if existing_entry:
+
+            # Nothing to update, return existing entry
+            return existing_entry
+        else:
+
+            # Check if the cvterm is already present in the database (look for cv_id and name)
+            existing_entry = self.query_first(cv.CvTerm, cv_id=new_entry.cv_id, name=new_entry.name)
+            if existing_entry:
+
+                # Nothing to update, return existing entry
+                return existing_entry
+            else:
+
+                # Insert new cvterm entry
+                self.add_and_flush(new_entry)
+                self.printer.print("Inserted term '" + new_entry.name + "' in vocabulary '" + vocabulary + "'")
+                return new_entry
+
+    def _handle_feature_dbxref(self, new_entry: sequence.FeatureDbxRef, existing_entries: List[sequence.FeatureDbxRef],
+                               crossref="", feature="") -> sequence.FeatureDbxRef:
+        """Inserts or updates an entry in the 'feature_dbxref' table, and returns it"""
+
+        # Check if the feature_dbxref is already present in the database
+        matching_entries = utils.filter_objects(existing_entries, dbxref_id=new_entry.dbxref_id)
+        if matching_entries:
+
+            # Check if the entries in database and file have the same properties (there can only be one)
+            matching_entry = matching_entries[0]
+            if self.update_feature_dbxref_properties(matching_entry, new_entry):
+                self.printer.print("Updated cross reference '" + crossref + "' for feature '" + feature + "'")
+            return matching_entry
+        else:
+
+            # Insert new feature_dbxref entry
+            self.add_and_flush(new_entry)
+            self.printer.print("Inserted cross reference '" + crossref + "' for feature '" + feature + "'")
+            return new_entry
+
+    def _handle_feature(self, new_entry: sequence.Feature, organism_name="") -> sequence.Feature:
+        """Inserts or updates an entry in the 'feature' table and returns it"""
+
+        # Check if the feature is already present in the database
+        existing_entry = self.query_first(sequence.Feature, organism_id=new_entry.organism_id,
+                                          type_id=new_entry.type_id, uniquename=new_entry.uniquename)
+        if existing_entry:
+
+            # Check if the entries in database and file have the same properties, and update if not
+            if self.update_feature_properties(existing_entry, new_entry):
+                self.printer.print("Updated feature '" + existing_entry.uniquename + "' for organism '"
+                                   + organism_name + "'")
+            return existing_entry
+        else:
+
+            # Insert new feature entry
+            self.add_and_flush(new_entry)
+            self.printer.print("Inserted feature '" + new_entry.uniquename + "' for organism '" + organism_name + "'")
+            return new_entry
+
+    def _handle_featureloc(self, new_entry: sequence.FeatureLoc, feature="") -> sequence.FeatureLoc:
+        """Inserts or updates an entry in the 'featureloc' table, and returns it"""
+
+        # Check if the featureloc is already present in the database
+        existing_entry = self.query_first(sequence.FeatureLoc, feature_id=new_entry.feature_id)
+        if existing_entry:
+
+            # Check if the entries in database and file have the same properties, and update if not
+            if self.update_featureloc_properties(existing_entry, new_entry):
+                self.printer.print("Updated featureloc for feature '" + feature + "'")
+            return existing_entry
+        else:
+
+            # Insert new featureloc entry
+            self.add_and_flush(new_entry)
+            self.printer.print("Inserted featureloc for feature '" + feature + "'")
+            return new_entry
+
+    def _handle_featureprop(self, new_entry: sequence.FeatureProp, existing_entries: List[sequence.FeatureProp],
+                            property_name="", value="", feature="") -> sequence.FeatureProp:
+        """Inserts or updates an entry in the 'featureprop' table, and returns it"""
+
+        # Check if the featureprop is already present in the database
+        matching_entries = utils.filter_objects(existing_entries, type_id=new_entry.type_id)
+        for matching_entry in matching_entries:
+
+            # Check if the entries in database and file have the same properties
+            if matching_entry.value == new_entry.value:
+
+                # Nothing to update; return existing entry
+                return matching_entry
+            else:
+
+                # Adjust 'rank' to avoid a violation of the UNIQUE constraint
+                new_entry.rank = max(new_entry.rank, matching_entry.rank+1)
+        else:
+
+            # Insert new featureprop entry
+            self.add_and_flush(new_entry)
+            self.printer.print("Inserted property '" + property_name + "' = '" + value + "' for feature '"
+                               + feature + "'")
+            return new_entry
+
+    def _handle_feature_cvterm(self, new_entry: sequence.FeatureCvTerm, existing_entries: List[sequence.FeatureCvTerm],
+                               term="", feature="") -> sequence.FeatureCvTerm:
+        """Inserts or updates an entry in the 'feature_cvterm' table, and returns it"""
+
+        # Check if the feature_cvterm is already present in the database
+        matching_entries = utils.filter_objects(existing_entries, cvterm_id=new_entry.cvterm_id)
+        if matching_entries:
+
+            # Nothing to update; return existing entry
+            # Note that there are potentially multiple entries (for different pub_ids/ranks). Ignored here.
+            return matching_entries[0]
+        else:
+
+            # Insert new feature_cvterm entry
+            self.add_and_flush(new_entry)
+            self.printer.print("Inserted CV term '" + term + "' for feature '" + feature + "'")
+            return new_entry
+
+    def _handle_feature_relationship(self, new_entry: sequence.FeatureRelationship,
+                                     existing_entries: List[sequence.FeatureRelationship],
+                                     subject_name="", object_name="", type_name="") -> sequence.FeatureRelationship:
+        """Inserts or updates an entry in the 'feature_relationship' table, and returns it"""
+
+        # Check if the feature_relationship is already present in the database
+        matching_entries = utils.filter_objects(existing_entries, type_id=new_entry.type_id,
+                                                object_id=new_entry.object_id)
+        if matching_entries:
+
+            # Check if the entries in database and file have the same properties, and update if not
+            # Note that there are potentially multiple entries (for different ranks). Ignored here.
+            matching_entry = matching_entries[0]
+            if self.update_feature_relationship_properties(matching_entry, new_entry):
+                self.printer.print("Updated relationship: '" + subject_name + "', '" + type_name + "', '"
+                                   + object_name + "'")
+            return matching_entry
+        else:
+
+            # Insert new feature_relationship entry
+            self.add_and_flush(new_entry)
+            self.printer.print("Inserted relationship: '" + subject_name + "', '" + type_name + "', '"
+                               + object_name + "'")
+            return new_entry
+
+    def _handle_synonym(self, new_entry: sequence.Synonym) -> sequence.Synonym:
+        """Inserts or updates an entry in the 'synonym' table, and returns it"""
+
+        # Check if the synonym is already present in the database
+        existing_entry = self.query_first(sequence.Synonym, name=new_entry.name, type_id=new_entry.type_id)
+        if existing_entry:
+
+            # Check if the entries in database and file have the same properties, and update if not
+            if self.update_synonym_properties(existing_entry, new_entry):
+                self.printer.print("Updated synonym '" + existing_entry.name + "'.")
+            return existing_entry
+        else:
+
+            # Insert a new synonym entry
+            self.add_and_flush(new_entry)
+            self.printer.print("Inserted synonym '" + new_entry.name + "'.")
+            return new_entry
+
+    def _handle_feature_synonym(self, new_entry: sequence.FeatureSynonym,
+                                existing_entries: List[sequence.FeatureSynonym], synonym="", feature=""
+                                ) -> sequence.FeatureSynonym:
+        """Inserts or updates an entry in the 'feature_synonym' table, and returns it"""
+
+        # Check if the feature_synonym is already present in the database
+        matching_entries = utils.filter_objects(existing_entries, synonym_id=new_entry.synonym_id)
+        if matching_entries:
+
+            # Check if the entries in database and file have the same properties, and update if not
+            # Note that there are potentially multiple entries (for different pub_ids). Ignored here.
+            matching_entry = matching_entries[0]
+            if self.update_feature_synonym_properties(matching_entry, new_entry):
+                self.printer.print("Updated synonym '" + synonym + "' for feature '" + feature + "'")
+            return matching_entry
+        else:
+
+            # Insert a new feature_synonym entry
+            self.add_and_flush(new_entry)
+            self.printer.print("Inserted synonym '" + synonym + "' for feature '" + feature + "'")
+            return new_entry
+
+    def _handle_pub(self, new_entry: pub.Pub) -> pub.Pub:
+        """Inserts or updates an entry in the 'pub' table, and returns it"""
+
+        # Check if the publication is already present in the database
+        existing_entry = self.query_first(pub.Pub, uniquename=new_entry.uniquename, type_id=new_entry.type_id)
+        if existing_entry:
+
+            # Check if the entries in database and file have the same properties, and update if not
+            if self.update_pub_properties(existing_entry, new_entry):
+                self.printer.print("Updated publication '" + new_entry.uniquename + "'")
+            return existing_entry
+        else:
+
+            # Insert a new feature_synonym entry
+            self.add_and_flush(new_entry)
+            self.printer.print("Inserted publication '" + new_entry.uniquename + "'")
+            return new_entry
+
+    def _handle_feature_pub(self, new_entry: sequence.FeaturePub, existing_entries: List[sequence.FeaturePub],
+                            feature="", publication="") -> sequence.FeaturePub:
+        """Inserts or updates an entry in the 'feature_pub' table, and returns it"""
+
+        # Check if the feature_pub is already present in the database
+        matching_entries = utils.filter_objects(existing_entries, pub_id=new_entry.pub_id)
+        if matching_entries:
+
+            # Nothing to update, return existing entry
+            matching_entry = matching_entries[0]
+            return matching_entry
+        else:
+
+            # Insert a new feature_pub entry
+            self.add_and_flush(new_entry)
+            self.printer.print("Inserted publication '" + publication + "' for feature '" + feature + "'")
+            return new_entry
+
+    @staticmethod
+    def update_pub_properties(existing_entry: pub.Pub, new_entry: pub.Pub) -> bool:
+        """Updates the properties of a pub entry in the database"""
+        updated = False
+        for attribute in ["title", "volume", "volumetitle", "series_name", "issue", "pyear", "pages", "miniref",
+                          "publisher", "pubplace", "is_obsolete"]:
+            if utils.copy_attribute(existing_entry, new_entry, attribute):
+                updated = True
+        return updated
+
+    @staticmethod
+    def update_feature_properties(existing_entry: sequence.Feature, new_entry: sequence.Feature) -> bool:
+        """Updates the properties of a feature entry in the database"""
+        updated = False
+        for attribute in ["name", "residues", "seqlen", "md5checksum", "is_analysis", "is_obsolete"]:
+            if utils.copy_attribute(existing_entry, new_entry, attribute):
+                updated = True
+        return updated
+
+    @staticmethod
+    def update_featureloc_properties(existing_entry: sequence.FeatureLoc, new_entry: sequence.FeatureLoc) -> bool:
+        """Updates the properties of a featureloc entry in the database"""
+        updated = False
+        for attribute in ["fmin", "fmax", "strand", "phase"]:
+            if utils.copy_attribute(existing_entry, new_entry, attribute):
+                updated = True
+        return updated
+
+    @staticmethod
+    def update_feature_dbxref_properties(existing_entry: sequence.FeatureDbxRef,
+                                         new_entry: sequence.FeatureDbxRef) -> bool:
+        """Updates the properties of a feature_dbxref entry in the database"""
+        updated = False
+        if utils.copy_attribute(existing_entry, new_entry, "is_current"):
+            updated = True
+        return updated
+
+    @staticmethod
+    def update_feature_relationship_properties(existing_entry: sequence.FeatureRelationship,
+                                               new_entry: sequence.FeatureRelationship) -> bool:
+        """Updates the properties of a feature_relationship entry in the database"""
+        updated = False
+        if utils.copy_attribute(existing_entry, new_entry, "value"):
+            updated = True
+        return updated
+
+    @staticmethod
+    def update_synonym_properties(existing_entry: sequence.Synonym, new_entry: sequence.Synonym) -> bool:
+        """Updates the properties of a synonym entry in the database"""
+        updated = False
+        if utils.copy_attribute(existing_entry, new_entry, "synonym_sgml"):
+            updated = True
+        return updated
+
+    @staticmethod
+    def update_feature_synonym_properties(existing_entry: sequence.FeatureSynonym,
+                                          new_entry: sequence.FeatureSynonym) -> bool:
+        """Updates the properties of a feature_synonym entry in the database"""
+        updated = False
+        for attribute in ["is_internal", "is_current"]:
+            if utils.copy_attribute(existing_entry, new_entry, attribute):
+                updated = True
+        return updated

--- a/pychado/orm/companalysis.py
+++ b/pychado/orm/companalysis.py
@@ -1,0 +1,110 @@
+import sqlalchemy.orm
+import sqlalchemy.sql.functions
+from . import base, cv, sequence
+
+# Object-relational mappings for the CHADO Companalysis module
+
+
+class Analysis(base.PublicBase):
+    """Class for the CHADO 'analysis' table"""
+    # Columns
+    analysis_id = sqlalchemy.Column(sqlalchemy.BIGINT, nullable=False, primary_key=True, autoincrement=True)
+    name = sqlalchemy.Column(sqlalchemy.VARCHAR(255), nullable=True)
+    desription = sqlalchemy.Column(sqlalchemy.TEXT, nullable=True)
+    program = sqlalchemy.Column(sqlalchemy.VARCHAR(255), nullable=False)
+    programversion = sqlalchemy.Column(sqlalchemy.VARCHAR(255), nullable=False)
+    algorithm = sqlalchemy.Column(sqlalchemy.VARCHAR(255), nullable=True)
+    sourcename = sqlalchemy.Column(sqlalchemy.VARCHAR(255), nullable=True)
+    sourceversion = sqlalchemy.Column(sqlalchemy.VARCHAR(255), nullable=True)
+    sourceuri = sqlalchemy.Column(sqlalchemy.TEXT, nullable=True)
+    timeexecuted = sqlalchemy.Column(sqlalchemy.TIMESTAMP, nullable=False,
+                                     server_default=sqlalchemy.sql.functions.now())
+
+    # Constraints
+    __tablename__ = "analysis"
+    __table_args__ = (sqlalchemy.UniqueConstraint(program, programversion, sourcename, name="analysis_c1"),)
+
+    # Initialisation
+    def __init__(self, program, programversion, name=None, description=None, algorithm=None, sourcename=None,
+                 sourceversion=None, sourceuri=None, timeexecuted=sqlalchemy.sql.functions.now(), analysis_id=None):
+        for key, value in locals().items():
+            if key != self:
+                setattr(self, key, value)
+
+    # Representation
+    def __repr__(self):
+        return "<companalysis.Analysis(analysis_id={0}, name='{1}', desription='{2}', program='{3}', " \
+               "programversion='{4}', algorithm='{5}', sourcename='{6}', sourceversion='{7}, sourceuri='{8}'," \
+               "timeexecuted='{9}')>".format(self.analysis_id, self.name, self.desription, self.program,
+                                             self.programversion, self.algorithm, self.sourcename, self.sourceversion,
+                                             self.sourceuri, self.timeexecuted)
+
+
+class AnalysisFeature(base.PublicBase):
+    """Class for the CHADO 'analysisfeature' table"""
+    # Columns
+    analysisfeature_id = sqlalchemy.Column(sqlalchemy.BIGINT, nullable=False, primary_key=True, autoincrement=True)
+    feature_id = sqlalchemy.Column(sqlalchemy.BIGINT, sqlalchemy.ForeignKey(
+        sequence.Feature.feature_id, onupdate="CASCADE", ondelete="CASCADE"), nullable=False)
+    analysis_id = sqlalchemy.Column(sqlalchemy.BIGINT, sqlalchemy.ForeignKey(
+        Analysis.analysis_id, onupdate="CASCADE", ondelete="CASCADE"), nullable=False)
+    rawscore = sqlalchemy.Column(sqlalchemy.FLOAT, nullable=True)
+    normscore = sqlalchemy.Column(sqlalchemy.FLOAT, nullable=True)
+    significance = sqlalchemy.Column(sqlalchemy.FLOAT, nullable=True)
+    identity = sqlalchemy.Column(sqlalchemy.FLOAT, nullable=True)
+
+    # Constraints
+    __tablename__ = "analysisfeature"
+    __table_args__ = (sqlalchemy.UniqueConstraint(feature_id, analysis_id, name="analysisfeature_c1"),
+                      sqlalchemy.Index("analysisfeature_idx1", feature_id),
+                      sqlalchemy.Index("analysisfeature_idx2", analysis_id))
+
+    # Relationships
+    feature = sqlalchemy.orm.relationship(sequence.Feature, foreign_keys=feature_id, backref="analysisfeature_feature")
+    analysis = sqlalchemy.orm.relationship(Analysis, foreign_keys=analysis_id, backref="analysisfeature_analysis")
+
+    # Initialisation
+    def __init__(self, feature_id, analysis_id, rawscore=None, normscore=None, significance=None, identity=None,
+                 analysisfeature_id=None):
+        for key, value in locals().items():
+            if key != self:
+                setattr(self, key, value)
+
+    # Representation
+    def __repr__(self):
+        return "<companalysis.AnalysisFeature(analysisfeature_id={0}, feature_id={1}, analysis_id={2}, rawscore={3}, " \
+               "normscore={4}, significance={5}, identity={6})>".\
+            format(self.analysisfeature_id, self.feature_id, self.analysis_id, self.rawscore, self.normscore,
+                   self.significance, self.identity)
+
+
+class AnalysisProp(base.PublicBase):
+    """Class for the CHADO 'analysisprop' table"""
+    # Columns
+    analysisprop_id = sqlalchemy.Column(sqlalchemy.BIGINT, nullable=False, primary_key=True, autoincrement=True)
+    analysis_id = sqlalchemy.Column(sqlalchemy.BIGINT, sqlalchemy.ForeignKey(
+        Analysis.analysis_id, onupdate="CASCADE", ondelete="CASCADE"), nullable=False)
+    type_id = sqlalchemy.Column(sqlalchemy.BIGINT, sqlalchemy.ForeignKey(
+        cv.CvTerm.cvterm_id, onupdate="CASCADE", ondelete="CASCADE"), nullable=False)
+    value = sqlalchemy.Column(sqlalchemy.TEXT, nullable=True)
+
+    # Constraints
+    __tablename__ = "analysisprop"
+    __table_args__ = (sqlalchemy.UniqueConstraint(analysis_id, type_id, value, name="analysisprop_c1"),
+                      sqlalchemy.Index("analysisprop_idx1", analysis_id),
+                      sqlalchemy.Index("analysisprop_idx2", type_id))
+
+    # Relationships
+    analysis = sqlalchemy.orm.relationship(Analysis, foreign_keys=analysis_id, backref="analysisprop_analysis")
+    type = sqlalchemy.orm.relationship(cv.CvTerm, foreign_keys=type_id, backref="analysisprop_type")
+
+    # Initialisation
+    def __init__(self, analysis_id, type_id, value=None, analysisprop_id=None):
+        for key, val in locals().items():
+            if key != self:
+                setattr(self, key, val)
+
+    # Representation
+    def __repr__(self):
+        return "<companalysis.AnalysisProp(analysisprop_id={0}, analysis_id={1}, type_id={2}, value='{3}')>". \
+            format(self.analysisprop_id, self.analysis_id, self.type_id, self.value)

--- a/pychado/orm/sequence.py
+++ b/pychado/orm/sequence.py
@@ -42,7 +42,7 @@ class Feature(base.PublicBase):
     type = sqlalchemy.orm.relationship(cv.CvTerm, foreign_keys=type_id, backref="feature_type")
 
     # Initialisation
-    def __init__(self, dbxref_id, organism_id, type_id, uniquename, name=None, residues=None, seqlen=None,
+    def __init__(self, organism_id, type_id, uniquename, dbxref_id=None, name=None, residues=None, seqlen=None,
                  md5checksum=None, is_analysis=False, is_obsolete=False, timeaccessioned=sqlalchemy.sql.functions.now(),
                  timelastmodified=sqlalchemy.sql.functions.now(), feature_id=None):
         for key, value in locals().items():

--- a/pychado/tasks.py
+++ b/pychado/tasks.py
@@ -1,5 +1,5 @@
 from . import utils, dbutils, queries, ddl
-from .io import direct, ontology
+from .io import direct, essentials, ontology, gff
 
 
 def create_connection_string(filename: str, dbname: str) -> str:
@@ -160,12 +160,20 @@ def run_delete_command(specifier: str, arguments, uri: str) -> None:
 
 def run_import_command(specifier: str, arguments, uri: str) -> None:
     """Imports data from a file into a database"""
-    file = arguments.input_file
-    if arguments.input_url:
+    file = None
+    if hasattr(arguments, "input_file") and arguments.input_file:
+        file = arguments.input_file
+    elif hasattr(arguments, "input_url") and arguments.input_url:
         file = utils.download_file(arguments.input_url)
 
-    if specifier == "ontology":
+    if specifier == "essentials":
+        loader = essentials.EssentialsClient(uri, arguments.verbose)
+        loader.load()
+    elif specifier == "ontology":
         loader = ontology.OntologyClient(uri, arguments.verbose)
         loader.load(file, arguments.format, arguments.database_authority)
+    elif specifier == "gff":
+        loader = gff.GFFImportClient(uri, arguments.verbose)
+        loader.load(file, arguments.organism)
     else:
         print("Functionality 'import " + specifier + "' is not yet implemented.")

--- a/pychado/tests/arguments_tests.py
+++ b/pychado/tests/arguments_tests.py
@@ -7,27 +7,28 @@ class TestCommands(unittest.TestCase):
 
     def test_init_commands(self):
         commands = chado_tools.init_commands()
+        self.assertEqual(len(commands), 2)
         self.assertIn("init", commands)
         self.assertIn("reset", commands)
-        self.assertNotIn("non_existent_command", commands)
 
     def test_general_commands(self):
         commands = chado_tools.general_commands()
+        self.assertEqual(len(commands), 2)
         self.assertIn("connect", commands)
         self.assertIn("query", commands)
-        self.assertNotIn("non_existent_command", commands)
 
     def test_wrapper_commands(self):
         commands = chado_tools.wrapper_commands()
+        self.assertEqual(len(commands), 5)
         self.assertIn("extract", commands)
         self.assertIn("insert", commands)
         self.assertIn("delete", commands)
         self.assertIn("import", commands)
         self.assertIn("admin", commands)
-        self.assertNotIn("non_existent_command", commands)
 
     def test_admin_commands(self):
         commands = chado_tools.admin_commands()
+        self.assertEqual(len(commands), 7)
         self.assertIn("create", commands)
         self.assertIn("drop", commands)
         self.assertIn("dump", commands)
@@ -38,6 +39,7 @@ class TestCommands(unittest.TestCase):
 
     def test_extract_commands(self):
         commands = chado_tools.extract_commands()
+        self.assertEqual(len(commands), 4)
         self.assertIn("organisms", commands)
         self.assertIn("cvterms", commands)
         self.assertIn("genedb_products", commands)
@@ -45,15 +47,20 @@ class TestCommands(unittest.TestCase):
 
     def test_insert_commands(self):
         commands = chado_tools.insert_commands()
+        self.assertEqual(len(commands), 1)
         self.assertIn("organism", commands)
 
     def test_delete_commands(self):
         commands = chado_tools.delete_commands()
+        self.assertEqual(len(commands), 1)
         self.assertIn("organism", commands)
 
     def test_import_commands(self):
         commands = chado_tools.import_commands()
+        self.assertEqual(len(commands), 3)
+        self.assertIn("essentials", commands)
         self.assertIn("ontology", commands)
+        self.assertIn("gff", commands)
 
 
 class TestArguments(unittest.TestCase):
@@ -218,13 +225,13 @@ class TestArguments(unittest.TestCase):
     def test_insert_organism_args(self):
         # Tests if the command line arguments for the subcommand 'chado insert organism' are parsed correctly
         args = ["chado", "insert", "organism", "-g", "testgenus", "-s", "testspecies", "-a", "testabbreviation",
-                "--common_name", "testname", "--infraspecific_name", "testinfra", "--comment", "testcomment", "testdb"]
+                "--common_name", "testname", "-i", "teststrain", "--comment", "testcomment", "testdb"]
         parsed_args = vars(chado_tools.parse_arguments(args))
         self.assertEqual(parsed_args["genus"], "testgenus")
         self.assertEqual(parsed_args["species"], "testspecies")
+        self.assertEqual(parsed_args["infraspecific_name"], "teststrain")
         self.assertEqual(parsed_args["abbreviation"], "testabbreviation")
         self.assertEqual(parsed_args["common_name"], "testname")
-        self.assertEqual(parsed_args["infraspecific_name"], "testinfra")
         self.assertEqual(parsed_args["comment"], "testcomment")
         self.assertEqual(parsed_args["dbname"], "testdb")
 
@@ -235,8 +242,14 @@ class TestArguments(unittest.TestCase):
         self.assertEqual(parsed_args["organism"], "testorganism")
         self.assertEqual(parsed_args["dbname"], "testdb")
 
+    def test_import_essentials_args(self):
+        # Tests if the command line arguments for the subcommand 'chado import essentials' are parsed correctly
+        args = ["chado", "import", "essentials", "testdb"]
+        parsed_args = vars(chado_tools.parse_arguments(args))
+        self.assertEqual(parsed_args["dbname"], "testdb")
+
     def test_import_ontology_args(self):
-        # Tests if the command line arguments for the subcommand 'chado import cv_terms' are parsed correctly
+        # Tests if the command line arguments for the subcommand 'chado import ontology' are parsed correctly
         args = ["chado", "import", "ontology", "-f", "testfile", "-A", "testauthority", "-F", "owl", "testdb"]
         parsed_args = vars(chado_tools.parse_arguments(args))
         self.assertEqual(parsed_args["input_file"], "testfile")
@@ -251,6 +264,14 @@ class TestArguments(unittest.TestCase):
         self.assertEqual(parsed_args["input_file"], "")
         self.assertEqual(parsed_args["input_url"], "testurl")
         self.assertEqual(parsed_args["format"], "obo")
+
+    def test_import_gff_args(self):
+        # Tests if the command line arguments for the subcommand 'chado import gff' are parsed correctly
+        args = ["chado", "import", "gff", "-f", "testfile", "-a", "testorganism", "testdb"]
+        parsed_args = vars(chado_tools.parse_arguments(args))
+        self.assertEqual(parsed_args["input_file"], "testfile")
+        self.assertEqual(parsed_args["organism"], "testorganism")
+        self.assertEqual(parsed_args["dbname"], "testdb")
 
 
 if __name__ == '__main__':

--- a/pychado/tests/io_base_tests.py
+++ b/pychado/tests/io_base_tests.py
@@ -1,7 +1,8 @@
 import unittest
 import sqlalchemy.ext.declarative
 from .. import dbutils, utils
-from ..io import iobase
+from ..orm import base, general, cv, organism, pub, sequence
+from ..io import iobase, essentials, direct
 
 test_base = sqlalchemy.ext.declarative.declarative_base()
 
@@ -21,7 +22,7 @@ class Species(test_base):
                 setattr(self, key, value)
 
 
-class TestBasicIO(unittest.TestCase):
+class TestIOClient(unittest.TestCase):
     """Tests basic functions for accessing databases via SQL"""
 
     connection_parameters = utils.parse_yaml(dbutils.default_configuration_file())
@@ -51,7 +52,7 @@ class TestBasicIO(unittest.TestCase):
         # Test the basic functionality for inserting data into database tables and retrieving data from them
 
         # Check the table is initially empty
-        empty_table = self.client.query_table(Species).first()
+        empty_table = self.client.query_first(Species)
         self.assertIsNone(empty_table)
 
         # Add an entry using 'add_and_flush', and assert that it automatically obtains an ID
@@ -60,7 +61,7 @@ class TestBasicIO(unittest.TestCase):
         self.assertIsNotNone(human.id)
 
         # Check the entry is in the database
-        retrieved_human = self.client.query_table(Species, name="human").first()
+        retrieved_human = self.client.query_first(Species, name="human")
         self.assertEqual(human, retrieved_human)
 
         # Add an entry using 'insert_into_table'
@@ -69,7 +70,7 @@ class TestBasicIO(unittest.TestCase):
         self.assertEqual(diplodocus.name, "diplodocus")
 
         # Check that there are now 2 entries in the table
-        full_table = self.client.query_table(Species).all()
+        full_table = self.client.query_all(Species)
         self.assertEqual(len(full_table), 2)
 
         # Try to insert the same entry again using find_or_insert
@@ -82,8 +83,386 @@ class TestBasicIO(unittest.TestCase):
         self.assertEqual(bumblebee.clade, "insects")
 
         # Check that there are now 2 entries in the table
-        full_table = self.client.query_table(Species).all()
+        full_table = self.client.query_all(Species)
         self.assertEqual(len(full_table), 3)
+
+
+class TestImportClient(unittest.TestCase):
+    """Test functions for loading data into a CHADO database"""
+
+    connection_parameters = utils.parse_yaml(dbutils.default_configuration_file())
+    connection_uri = dbutils.random_database_uri(connection_parameters)
+
+    @classmethod
+    def setUpClass(cls):
+        # Creates a database, establishes a connection, creates tables and populates them with essential entries
+        dbutils.create_database(cls.connection_uri)
+        schema_base = base.PublicBase
+        schema_metadata = schema_base.metadata
+        essentials_client = essentials.EssentialsClient(cls.connection_uri)
+        schema_metadata.create_all(essentials_client.engine, tables=schema_metadata.sorted_tables)
+        essentials_client.load()
+        cls.client = iobase.ImportClient(cls.connection_uri)
+
+    @classmethod
+    def tearDownClass(cls):
+        # Drops the database
+        dbutils.drop_database(cls.connection_uri, True)
+
+    def setUp(self):
+        # Inserts default entries into database tables
+        (self.default_db, self.default_dbxref, self.default_cv, self.default_cvterm, self.default_organism,
+         self.default_feature, self.default_pub, self.default_synonym) = self.insert_default_entries()
+
+    def tearDown(self):
+        # Rolls back all changes to the database
+        self.client.session.rollback()
+
+    def insert_default_entries(self):
+        # Inserts CV terms needed as basis for virtually all tests
+        default_db = general.Db(name="defaultdb")
+        self.client.add_and_flush(default_db)
+        default_dbxref = general.DbxRef(db_id=default_db.db_id, accession="defaultaccession")
+        self.client.add_and_flush(default_dbxref)
+        default_cv = cv.Cv(name="defaultcv")
+        self.client.add_and_flush(default_cv)
+        default_cvterm = cv.CvTerm(cv_id=default_cv.cv_id, dbxref_id=default_dbxref.dbxref_id, name="defaultterm")
+        self.client.add_and_flush(default_cvterm)
+        default_organism = organism.Organism(genus="defaultgenus", species="defaultspecies", abbreviation="defaultorg")
+        self.client.add_and_flush(default_organism)
+        default_feature = sequence.Feature(organism_id=default_organism.organism_id, type_id=default_cvterm.cvterm_id,
+                                           uniquename="defaultfeature")
+        self.client.add_and_flush(default_feature)
+        default_pub = pub.Pub(uniquename="defaultpub", type_id=default_cvterm.cvterm_id)
+        self.client.add_and_flush(default_pub)
+        default_synonym = sequence.Synonym(name="defaultsynonym", type_id=default_cvterm.cvterm_id, synonym_sgml="")
+        self.client.add_and_flush(default_synonym)
+        return (default_db, default_dbxref, default_cv, default_cvterm, default_organism, default_feature, default_pub,
+                default_synonym)
+
+    def test_load_cvterm(self):
+        # Tests the function loading a CV term from the database
+        comment_term = self.client._load_cvterm("comment")
+        self.assertEqual("comment", comment_term.name)
+        with self.assertRaises(iobase.DatabaseError):
+            self.client._load_cvterm("inexistent_term")
+
+    def test_load_cvterms(self):
+        # Tests the function loading multiple CV terms from the database
+        synonym_type_terms = self.client._load_cvterms("synonym_type", ["narrow", "broad"], False)
+        self.assertIn("narrow", synonym_type_terms)
+        self.assertEqual(synonym_type_terms["narrow"].name, "narrow")
+        with self.assertRaises(iobase.DatabaseError):
+            self.client._load_cvterms("synonym_type", ["inexistent_term"], False)
+        with self.assertRaises(iobase.DatabaseError):
+            self.client._load_cvterms("inexistent_vocabulary", [])
+
+    def test_load_organism(self):
+        # Tests the function loading an organism from the database
+        with self.assertRaises(iobase.DatabaseError):
+            self.client._load_organism("testorganism")
+        testclient = direct.DirectIOClient(self.connection_uri)
+        testclient.insert_organism(genus="testgenus", species="testspecies", abbreviation="testorganism")
+        testorganism = self.client._load_organism("testorganism")
+        self.assertEqual(testorganism.species, "testspecies")
+
+    def test_load_pub(self):
+        # Tests the function loading a publication from the database
+        testpub = self.client._load_pub("null")
+        self.assertEqual("null", testpub.uniquename)
+        with self.assertRaises(iobase.DatabaseError):
+            self.client._load_pub("inexistent_pub")
+
+    def test_handle_feature(self):
+        # Tests the function importing a feature to the database
+        new_entry = sequence.Feature(organism_id=self.default_organism.organism_id,
+                                     type_id=self.default_cvterm.cvterm_id, uniquename="testname", name="name1")
+        first_entry = self.client._handle_feature(new_entry)
+        self.assertIsNotNone(first_entry.feature_id)
+        self.assertEqual(first_entry.uniquename, "testname")
+        self.assertEqual(first_entry.name, "name1")
+
+        another_entry = sequence.Feature(organism_id=self.default_organism.organism_id,
+                                         type_id=self.default_cvterm.cvterm_id, uniquename="testname", name="name2")
+        second_entry = self.client._handle_feature(another_entry)
+        self.assertIs(second_entry, first_entry)
+        self.assertEqual(second_entry.name, "name2")
+
+        yet_another_entry = sequence.Feature(organism_id=self.default_organism.organism_id,
+                                             type_id=self.default_cvterm.cvterm_id, uniquename="othername")
+        third_entry = self.client._handle_feature(yet_another_entry)
+        self.assertIsNot(third_entry, first_entry)
+        self.assertEqual(third_entry.uniquename, "othername")
+
+    def test_handle_featureloc(self):
+        # Tests the function importing a featureloc to the database
+        other_feature = sequence.Feature(organism_id=self.default_organism.organism_id,
+                                         type_id=self.default_cvterm.cvterm_id, uniquename="othername")
+        self.client.add_and_flush(other_feature)
+        new_entry = sequence.FeatureLoc(feature_id=self.default_feature.feature_id,
+                                        srcfeature_id=other_feature.feature_id, strand=1)
+        first_entry = self.client._handle_featureloc(new_entry)
+        self.assertIsNotNone(first_entry.featureloc_id)
+        self.assertEqual(first_entry.strand, 1)
+
+        another_entry = sequence.FeatureLoc(feature_id=self.default_feature.feature_id,
+                                            srcfeature_id=other_feature.feature_id, strand=-1)
+        second_entry = self.client._handle_featureloc(another_entry)
+        self.assertIs(second_entry, first_entry)
+        self.assertEqual(second_entry.strand, -1)
+
+    def test_handle_db(self):
+        # Tests the function importing a db to the database
+        new_entry = general.Db(name="testname")
+        first_entry = self.client._handle_db(new_entry)
+        self.assertIsNotNone(first_entry.db_id)
+        self.assertEqual(first_entry.name, "testname")
+
+        another_entry = general.Db(name="testname")
+        second_entry = self.client._handle_db(another_entry)
+        self.assertIs(second_entry, first_entry)
+
+    def test_handle_dbxref(self):
+        # Tests the function importing a db cross reference to the database
+        new_entry = general.DbxRef(db_id=self.default_db.db_id, accession="testaccession", version="testversion")
+        first_entry = self.client._handle_dbxref(new_entry)
+        self.assertIsNotNone(first_entry.dbxref_id)
+        self.assertEqual(first_entry.accession, "testaccession")
+
+        another_entry = general.DbxRef(db_id=self.default_db.db_id, accession="testaccession", version="testversion")
+        second_entry = self.client._handle_dbxref(another_entry)
+        self.assertIs(second_entry, first_entry)
+
+        another_entry.accession = "otheraccession"
+        third_entry = self.client._handle_dbxref(another_entry)
+        self.assertIsNot(third_entry, first_entry)
+        self.assertEqual(third_entry.accession, "otheraccession")
+
+    def test_handle_cv(self):
+        # Tests the function importing a controlled vocabulary to the database
+        new_entry = cv.Cv(name="testname")
+        first_entry = self.client._handle_cv(new_entry)
+        self.assertIsNotNone(first_entry.cv_id)
+        self.assertEqual(first_entry.name, "testname")
+
+        another_entry = cv.Cv(name="testname")
+        second_entry = self.client._handle_cv(another_entry)
+        self.assertIs(second_entry, first_entry)
+
+    def test_handle_cvterm(self):
+        # Tests the function importing a term of a controlled vocabulary to the database
+        # Insert a CV term
+        test_dbxref = general.DbxRef(db_id=self.default_db.db_id, accession="testaccession")
+        self.client.add_and_flush(test_dbxref)
+        new_entry = cv.CvTerm(cv_id=self.default_cv.cv_id, name="testname", dbxref_id=test_dbxref.dbxref_id)
+        first_entry = self.client._handle_cvterm(new_entry)
+        self.assertIsNotNone(first_entry.cvterm_id)
+        self.assertEqual(first_entry.name, "testname")
+
+        # Try to insert another CV term with same cv_id/name, and check that the previously inserted entry is returned
+        other_dbxref = general.DbxRef(db_id=self.default_db.db_id, accession="otheraccession")
+        self.client.add_and_flush(other_dbxref)
+        another_entry = cv.CvTerm(cv_id=self.default_cv.cv_id, name="testname", dbxref_id=other_dbxref.dbxref_id)
+        second_entry = self.client._handle_cvterm(another_entry)
+        self.assertIs(second_entry, first_entry)
+
+        # Try to insert another CV term with same dbxref, and check that the previously inserted entry is returned
+        other_cv = cv.Cv(name="othervocabulary")
+        self.client.add_and_flush(other_cv)
+        yet_another_entry = cv.CvTerm(cv_id=other_cv.cv_id, name="testname", dbxref_id=test_dbxref.dbxref_id)
+        third_entry = self.client._handle_cvterm(yet_another_entry)
+        self.assertIs(third_entry, first_entry)
+
+        # Try to insert another CV term with different dbxref and different name, and check that this succeeds
+        another_entry.name = "othername"
+        fourth_entry = self.client._handle_cvterm(another_entry)
+        self.assertIsNot(fourth_entry, first_entry)
+        self.assertEqual(fourth_entry.name, "othername")
+
+    def test_handle_feature_dbxref(self):
+        # Tests the function importing a feature_dbxref to the database
+        new_entry = sequence.FeatureDbxRef(feature_id=self.default_feature.feature_id,
+                                           dbxref_id=self.default_dbxref.dbxref_id, is_current=True)
+        first_entry = self.client._handle_feature_dbxref(new_entry, [])
+        self.assertIsNotNone(first_entry.feature_dbxref_id)
+        self.assertTrue(first_entry.is_current)
+
+        another_entry = sequence.FeatureDbxRef(feature_id=self.default_feature.feature_id,
+                                               dbxref_id=self.default_dbxref.dbxref_id, is_current=False)
+        existing_entries = self.client.query_all(sequence.FeatureDbxRef, feature_id=new_entry.feature_id)
+        second_entry = self.client._handle_feature_dbxref(another_entry, existing_entries)
+        self.assertIs(second_entry, first_entry)
+        self.assertFalse(second_entry.is_current)
+
+    def test_handle_featureprop(self):
+        # Tests the function importing a featureprop to the database
+        new_entry = sequence.FeatureProp(feature_id=self.default_feature.feature_id,
+                                         type_id=self.default_cvterm.cvterm_id, value="testvalue")
+        first_entry = self.client._handle_featureprop(new_entry, [])
+        self.assertIsNotNone(first_entry.featureprop_id)
+        self.assertEqual(first_entry.rank, 0)
+
+        another_entry = sequence.FeatureProp(feature_id=self.default_feature.feature_id,
+                                             type_id=self.default_cvterm.cvterm_id, value="testvalue")
+        existing_entries = self.client.query_all(sequence.FeatureProp, feature_id=new_entry.feature_id)
+        second_entry = self.client._handle_featureprop(another_entry, existing_entries)
+        self.assertIs(second_entry, first_entry)
+
+        yet_another_entry = sequence.FeatureProp(feature_id=self.default_feature.feature_id,
+                                                 type_id=self.default_cvterm.cvterm_id, value="othervalue")
+        third_entry = self.client._handle_featureprop(yet_another_entry, existing_entries)
+        self.assertIsNot(third_entry, first_entry)
+        self.assertEqual(third_entry.rank, 1)
+
+    def test_handle_feature_cvterm(self):
+        # Tests the function importing a feature_cvterm to the database
+        new_entry = sequence.FeatureCvTerm(feature_id=self.default_feature.feature_id,
+                                           cvterm_id=self.default_cvterm.cvterm_id, pub_id=self.default_pub.pub_id)
+        first_entry = self.client._handle_feature_cvterm(new_entry, [])
+        self.assertIsNotNone(first_entry.feature_cvterm_id)
+        self.assertEqual(first_entry.rank, 0)
+
+        another_entry = sequence.FeatureCvTerm(feature_id=self.default_feature.feature_id,
+                                               cvterm_id=self.default_cvterm.cvterm_id, pub_id=self.default_pub.pub_id,
+                                               rank=1)
+        existing_entries = self.client.query_all(sequence.FeatureCvTerm, feature_id=new_entry.feature_id)
+        second_entry = self.client._handle_feature_cvterm(another_entry, existing_entries)
+        self.assertIs(second_entry, first_entry)
+
+    def test_handle_feature_relationship(self):
+        # Tests the function importing a feature_relationship to the database
+        other_feature = sequence.Feature(organism_id=self.default_organism.organism_id,
+                                         type_id=self.default_cvterm.cvterm_id, uniquename="otherfeature")
+        self.client.add_and_flush(other_feature)
+        new_entry = sequence.FeatureRelationship(subject_id=self.default_feature.feature_id,
+                                                 object_id=other_feature.feature_id,
+                                                 type_id=self.default_cvterm.cvterm_id, value="testvalue")
+        first_entry = self.client._handle_feature_relationship(new_entry, [])
+        self.assertIsNotNone(first_entry.feature_relationship_id)
+        self.assertEqual(first_entry.value, "testvalue")
+
+        another_entry = sequence.FeatureRelationship(subject_id=self.default_feature.feature_id,
+                                                     object_id=other_feature.feature_id,
+                                                     type_id=self.default_cvterm.cvterm_id, value="othervalue")
+        existing_entries = self.client.query_all(sequence.FeatureRelationship, subject_id=new_entry.subject_id)
+        second_entry = self.client._handle_feature_relationship(another_entry, existing_entries)
+        self.assertIs(second_entry, first_entry)
+        self.assertEqual(second_entry.value, "othervalue")
+
+    def test_handle_synonym(self):
+        # Tests the function importing a synonym to the database
+        new_entry = sequence.Synonym(name="testname", type_id=self.default_cvterm.cvterm_id, synonym_sgml="testsgml")
+        first_entry = self.client._handle_synonym(new_entry)
+        self.assertIsNotNone(first_entry.synonym_id)
+        self.assertEqual(first_entry.synonym_sgml, "testsgml")
+
+        another_entry = sequence.Synonym(name="testname", type_id=self.default_cvterm.cvterm_id, synonym_sgml="sgml")
+        second_entry = self.client._handle_synonym(another_entry)
+        self.assertIs(second_entry, first_entry)
+        self.assertEqual(second_entry.synonym_sgml, "sgml")
+
+    def test_handle_feature_synonym(self):
+        # Tests the function importing a feature_synonym to the database
+        new_entry = sequence.FeatureSynonym(synonym_id=self.default_synonym.synonym_id,
+                                            feature_id=self.default_feature.feature_id,
+                                            pub_id=self.default_pub.pub_id, is_current=True)
+        first_entry = self.client._handle_feature_synonym(new_entry, [])
+        self.assertIsNotNone(first_entry.feature_synonym_id)
+        self.assertTrue(first_entry.is_current)
+
+        another_entry = sequence.FeatureSynonym(synonym_id=self.default_synonym.synonym_id,
+                                                feature_id=self.default_feature.feature_id,
+                                                pub_id=self.default_pub.pub_id, is_current=False)
+        existing_entries = self.client.query_all(sequence.FeatureSynonym, feature_id=new_entry.feature_id)
+        second_entry = self.client._handle_feature_synonym(another_entry, existing_entries)
+        self.assertIs(second_entry, first_entry)
+        self.assertFalse(second_entry.is_current)
+
+    def test_handle_pub(self):
+        # Tests the function importing a publication to the database
+        new_entry = pub.Pub(uniquename="testname", type_id=self.default_cvterm.cvterm_id, volume="testvolume")
+        first_entry = self.client._handle_pub(new_entry)
+        self.assertIsNotNone(first_entry.pub_id)
+        self.assertEqual(first_entry.volume, "testvolume")
+
+        another_entry = pub.Pub(uniquename="testname", type_id=self.default_cvterm.cvterm_id, volume="othervolume")
+        second_entry = self.client._handle_pub(another_entry)
+        self.assertIs(second_entry, first_entry)
+        self.assertEqual(second_entry.volume, "othervolume")
+
+    def test_handle_featurepub(self):
+        # Tests the function importing a feature_pub to the database
+        new_entry = sequence.FeaturePub(feature_id=self.default_feature.feature_id, pub_id=self.default_pub.pub_id)
+        first_entry = self.client._handle_feature_pub(new_entry, [])
+        self.assertIsNotNone(first_entry.feature_pub_id)
+
+        another_entry = sequence.FeaturePub(feature_id=self.default_feature.feature_id, pub_id=self.default_pub.pub_id)
+        existing_entries = self.client.query_all(sequence.FeaturePub, feature_id=new_entry.feature_id)
+        second_entry = self.client._handle_feature_pub(another_entry, existing_entries)
+        self.assertIs(second_entry, first_entry)
+
+    def test_update_feature_properties(self):
+        # Tests the function that transfers properties from one feature object to another
+        feature1 = sequence.Feature(organism_id=1, type_id=1, dbxref_id=1, uniquename="testname", name="name1",
+                                    residues="ACGT", seqlen=4, is_analysis=False, is_obsolete=False)
+        feature2 = sequence.Feature(organism_id=1, type_id=1, dbxref_id=2, uniquename="othername", name="name2",
+                                    residues="TTT", seqlen=3, is_analysis=True, is_obsolete=True)
+        updated = self.client.update_feature_properties(feature1, feature2)
+        self.assertTrue(updated)
+        self.assertEqual(feature1.name, "name2")
+        self.assertEqual(feature1.residues, "TTT")
+        self.assertTrue(feature1.is_obsolete)
+
+    def test_update_featureloc_properties(self):
+        # Tests the function that transfers properties from one featureloc object to another
+        featureloc1 = sequence.FeatureLoc(feature_id=1, srcfeature_id=1, fmin=0, fmax=100, strand=1, phase=1)
+        featureloc2 = sequence.FeatureLoc(feature_id=1, srcfeature_id=1, fmin=20, fmax=30, strand=-1, phase=2)
+        updated = self.client.update_featureloc_properties(featureloc1, featureloc2)
+        self.assertTrue(updated)
+        self.assertEqual(featureloc1.fmin, 20)
+        self.assertEqual(featureloc1.strand, -1)
+
+    def test_update_synonym_properties(self):
+        # Tests the function that transfers properties from one synonym object to another
+        synonym1 = sequence.Synonym(name="testname", type_id=1, synonym_sgml="testsgml")
+        synonym2 = sequence.Synonym(name="testname", type_id=1, synonym_sgml="othersgml")
+        updated = self.client.update_synonym_properties(synonym1, synonym2)
+        self.assertTrue(updated)
+        self.assertEqual(synonym1.synonym_sgml, "othersgml")
+
+    def test_update_feature_synonym_properties(self):
+        # Tests the function that transfers properties from one feature_synonym object to another
+        feature_synonym1 = sequence.FeatureSynonym(synonym_id=1, feature_id=1, pub_id=1, is_current=True,
+                                                   is_internal=True)
+        feature_synonym2 = sequence.FeatureSynonym(synonym_id=1, feature_id=1, pub_id=1, is_current=False,
+                                                   is_internal=False)
+        updated = self.client.update_feature_synonym_properties(feature_synonym1, feature_synonym2)
+        self.assertTrue(updated)
+        self.assertFalse(feature_synonym1.is_current)
+
+    def test_update_feature_relationship_properties(self):
+        # Tests the function that transfers properties from one feature_relationship object to another
+        feature_relationship1 = sequence.FeatureRelationship(subject_id=1, object_id=1, type_id=1, value="testvalue")
+        feature_relationship2 = sequence.FeatureRelationship(subject_id=1, object_id=1, type_id=1, value="othervalue")
+        updated = self.client.update_feature_relationship_properties(feature_relationship1, feature_relationship2)
+        self.assertTrue(updated)
+        self.assertEqual(feature_relationship1.value, "othervalue")
+
+    def test_update_feature_dbxref_properties(self):
+        # Tests the function that transfers properties from one feature_dbxref object to another
+        feature_dbxref1 = sequence.FeatureDbxRef(dbxref_id=1, feature_id=1, is_current=True)
+        feature_dbxref2 = sequence.FeatureDbxRef(dbxref_id=1, feature_id=1, is_current=False)
+        updated = self.client.update_feature_dbxref_properties(feature_dbxref1, feature_dbxref2)
+        self.assertTrue(updated)
+        self.assertFalse(feature_dbxref1.is_current)
+
+    def test_update_pub_properties(self):
+        # Tests the function that transfers properties from one pub object to another
+        pub1 = pub.Pub(uniquename="testname", type_id=1, title="testtitle", volume="testvolume")
+        pub2 = pub.Pub(uniquename="testname", type_id=1, title="othertitle", volume="othervolume")
+        updated = self.client.update_pub_properties(pub1, pub2)
+        self.assertTrue(updated)
+        self.assertEqual(pub1.volume, "othervolume")
 
 
 if __name__ == '__main__':

--- a/pychado/tests/io_essentials_tests.py
+++ b/pychado/tests/io_essentials_tests.py
@@ -1,0 +1,102 @@
+import unittest
+from .. import dbutils, utils
+from ..io import essentials
+from ..orm import base, general, cv, pub
+
+
+class TestEssentials(unittest.TestCase):
+    """Tests various functions used to load an ontology from a file into a database"""
+
+    connection_parameters = utils.parse_yaml(dbutils.default_configuration_file())
+    connection_uri = dbutils.random_database_uri(connection_parameters)
+
+    @classmethod
+    def setUpClass(cls):
+        # Creates a database, establishes a connection, and creates tables
+        dbutils.create_database(cls.connection_uri)
+        schema_base = base.PublicBase
+        schema_metadata = schema_base.metadata
+        cls.client = essentials.EssentialsClient(cls.connection_uri)
+        schema_metadata.create_all(cls.client.engine, tables=schema_metadata.sorted_tables)
+
+    @classmethod
+    def tearDownClass(cls):
+        # Drops the database
+        dbutils.drop_database(cls.connection_uri, True)
+
+    def tearDown(self):
+        # Rolls back all changes to the database
+        self.client.session.rollback()
+
+    def test_load_generic_entries(self):
+        # Tests the loading of default entries into the main tables of the Chado database
+        self.client._load_generic_entries()
+        null_db = self.client.query_first(general.Db)                                       # type: general.Db
+        self.assertIsNotNone(null_db.db_id)
+        self.assertEqual(null_db.name, "null")
+        null_dbxref = self.client.query_first(general.DbxRef)                               # type: general.DbxRef
+        self.assertIsNotNone(null_dbxref.dbxref_id)
+        self.assertEqual(null_dbxref.accession, "null")
+        null_cv = self.client.query_first(cv.Cv)                                            # type: cv.Cv
+        self.assertIsNotNone(null_cv.cv_id)
+        self.assertEqual(null_cv.name, "null")
+        null_cvterm = self.client.query_first(cv.CvTerm)                                    # type: cv.CvTerm
+        self.assertIsNotNone(null_cvterm.cvterm_id)
+        self.assertEqual(null_cvterm.name, "null")
+        null_pub = self.client.query_first(pub.Pub)                                         # type: pub.Pub
+        self.assertIsNotNone(null_pub.pub_id)
+        self.assertEqual(null_pub.uniquename, "null")
+
+    def test_load_relationship_entries(self):
+        # Tests the loading of relationship entries into the Chado 'cvterm' table
+        self.client._load_relationship_entries()
+        relationship_cv = self.client.query_first(cv.Cv, name="relationship")               # type: cv.Cv
+        self.assertIsNotNone(relationship_cv.cv_id)
+        is_a_term = self.client.query_first(cv.CvTerm, name="is_a")                         # type: cv.CvTerm
+        self.assertIsNotNone(is_a_term.cvterm_id)
+        self.assertEqual(is_a_term.cv_id, relationship_cv.cv_id)
+        self.assertEqual(is_a_term.is_relationshiptype, 1)
+        self.client._load_relationship_entries("has_part")
+        has_part_term = self.client.query_first(cv.CvTerm, name="has_part")                 # type: cv.CvTerm
+        self.assertIsNotNone(has_part_term.cvterm_id)
+
+    def test_load_synonymtype_entries(self):
+        # Tests the loading of synonym type entries into the Chado 'cvterm' table
+        self.client._load_synonymtype_entries()
+        synonym_type_cv = self.client.query_first(cv.Cv, name="synonym_type")               # type: cv.Cv
+        self.assertIsNotNone(synonym_type_cv.cv_id)
+        narrow_cvterm = self.client.query_first(cv.CvTerm, name="narrow")                   # type: cv.CvTerm
+        self.assertIsNotNone(narrow_cvterm.cvterm_id)
+        self.assertEqual(narrow_cvterm.cv_id, synonym_type_cv.cv_id)
+
+    def test_load_cvterm_property_type_entries(self):
+        # Tests the loading of cvterm property type entries into the Chado 'cvterm' table
+        self.client._load_cvterm_property_type_entries()
+        property_type_cv = self.client.query_first(cv.Cv, name="cvterm_property_type")      # type: cv.Cv
+        self.assertIsNotNone(property_type_cv.cv_id)
+        symmetric_cvterm = self.client.query_first(cv.CvTerm, name="is_symmetric")          # type: cv.CvTerm
+        self.assertIsNotNone(symmetric_cvterm.cvterm_id)
+        self.assertEqual(symmetric_cvterm.cv_id, property_type_cv.cv_id)
+        self.assertEqual(symmetric_cvterm.is_relationshiptype, 0)
+        disjoint_cvterm = self.client.query_first(cv.CvTerm, name="disjoint_from")          # type: cv.CvTerm
+        self.assertIsNotNone(disjoint_cvterm.cvterm_id)
+        self.assertEqual(disjoint_cvterm.cv_id, property_type_cv.cv_id)
+        self.assertEqual(disjoint_cvterm.is_relationshiptype, 1)
+
+    def test_load_feature_property_entries(self):
+        # Tests the loading of feature property entries into the Chado 'cvterm' table
+        self.client._load_feature_property_entries()
+        feature_property_cv = self.client.query_first(cv.Cv, name="feature_property")       # type: cv.Cv
+        self.assertIsNotNone(feature_property_cv.cv_id)
+        comment_cvterm = self.client.query_first(cv.CvTerm, name="comment")                 # type: cv.CvTerm
+        self.assertIsNotNone(comment_cvterm.cvterm_id)
+        self.assertEqual(comment_cvterm.cv_id, feature_property_cv.cv_id)
+
+    def test_load_genedb_synonymtype_entries(self):
+        # Tests the loading of specific GeneDB synonym type entries into the Chado 'cvterm' table
+        self.client._load_genedb_synonymtype_entries()
+        synonym_type_cv = self.client.query_first(cv.Cv, name="genedb_synonym_type")        # type: cv.Cv
+        self.assertIsNotNone(synonym_type_cv.cv_id)
+        systematic_id_cvterm = self.client.query_first(cv.CvTerm, name="systematic_id")     # type: cv.CvTerm
+        self.assertIsNotNone(systematic_id_cvterm.cvterm_id)
+        self.assertEqual(systematic_id_cvterm.cv_id, synonym_type_cv.cv_id)

--- a/pychado/tests/io_gff_tests.py
+++ b/pychado/tests/io_gff_tests.py
@@ -1,0 +1,375 @@
+import unittest.mock
+import gffutils
+from .. import dbutils, utils
+from ..io import essentials, gff
+from ..orm import base, general, cv, organism, pub, sequence
+
+
+class TestGFF(unittest.TestCase):
+    """Tests various functions used to load a GFF file into a database"""
+
+    connection_parameters = utils.parse_yaml(dbutils.default_configuration_file())
+    connection_uri = dbutils.random_database_uri(connection_parameters)
+
+    @classmethod
+    def setUpClass(cls):
+        # Creates a database, establishes a connection, creates tables and populates them with essential entries
+        dbutils.create_database(cls.connection_uri)
+        schema_base = base.PublicBase
+        schema_metadata = schema_base.metadata
+        essentials_client = essentials.EssentialsClient(cls.connection_uri)
+        schema_metadata.create_all(essentials_client.engine, tables=schema_metadata.sorted_tables)
+        essentials_client.load()
+        essentials_client._load_further_relationship_entries()
+        essentials_client._load_sequence_type_entries()
+        cls.client = gff.GFFImportClient(cls.connection_uri)
+
+    @classmethod
+    def tearDownClass(cls):
+        # Drops the database
+        dbutils.drop_database(cls.connection_uri, True)
+
+    def setUp(self):
+        # Inserts default entries into database tables
+        self.default_gff_entry = gffutils.Feature(
+            id="testid", seqid="testseqid", source="testsource", featuretype="testtype", start=1, end=30, score="3.5",
+            strand="+", frame="2", attributes={
+                "Name": ["testname"], "translation": ["MCRA"], "literature": ["PMID:12334"], "Alias": ["testalias"],
+                "previous_systematic_id": "testsynonym", "Parent": "testparent", "Dbxref": ["testdb:testaccession"],
+                "Ontology_term": ["GO:7890"], "Note": "testnote"})
+
+    def tearDown(self):
+        # Rolls back all changes to the database
+        self.client.session.rollback()
+
+    def insert_default_entries(self):
+        # Inserts CV terms needed as basis for virtually all tests
+        default_db = general.Db(name="defaultdb")
+        self.client.add_and_flush(default_db)
+        default_dbxref = general.DbxRef(db_id=default_db.db_id, accession="defaultaccession")
+        self.client.add_and_flush(default_dbxref)
+        default_cv = cv.Cv(name="defaultcv")
+        self.client.add_and_flush(default_cv)
+        default_cvterm = cv.CvTerm(cv_id=default_cv.cv_id, dbxref_id=default_dbxref.dbxref_id, name="testterm")
+        self.client.add_and_flush(default_cvterm)
+        return default_db, default_dbxref, default_cv, default_cvterm
+
+    @unittest.mock.patch("pychado.io.gff.GFFImportClient._handle_feature")
+    @unittest.mock.patch("pychado.io.gff.GFFImportClient._create_feature")
+    def test_handle_child_feature(self, mock_create: unittest.mock.Mock, mock_insert: unittest.mock.Mock):
+        # Tests the function transferring data from a GFF file entry to the 'feature' table
+        self.assertIs(mock_create, self.client._create_feature)
+        self.assertIs(mock_insert, self.client._handle_feature)
+        organism_entry = organism.Organism(genus="", species="", abbreviation="testorganism", organism_id=1)
+        feature_entry = self.client._handle_child_feature(self.default_gff_entry, organism_entry)
+        self.assertIsNone(feature_entry)
+        mock_create.assert_not_called()
+
+        self.default_gff_entry.featuretype = "gene"
+        mock_create.return_value = "AAA"
+        self.client._handle_child_feature(self.default_gff_entry, organism_entry)
+        mock_create.assert_called_with(self.default_gff_entry, 1, self.client._sequence_terms["gene"].cvterm_id)
+        mock_insert.assert_called_with("AAA", "testorganism")
+
+    @unittest.mock.patch("pychado.io.gff.GFFImportClient._handle_featureloc")
+    @unittest.mock.patch("pychado.io.gff.GFFImportClient._create_featureloc")
+    @unittest.mock.patch("pychado.io.gff.GFFImportClient.query_first")
+    def test_handle_location(self, mock_query: unittest.mock.Mock, mock_create: unittest.mock.Mock,
+                             mock_insert: unittest.mock.Mock):
+        # Tests the function transferring data from a GFF file entry to the 'feature' table
+        self.assertIs(mock_query, self.client.query_first)
+        self.assertIs(mock_create, self.client._create_featureloc)
+        self.assertIs(mock_insert, self.client._handle_featureloc)
+
+        feature_entry = sequence.Feature(organism_id=11, type_id=200, uniquename="testname", feature_id=1)
+        mock_query.return_value = sequence.Feature(organism_id=11, type_id=300, uniquename="chromname", feature_id=2)
+
+        featureloc_entry = self.client._handle_location(self.default_gff_entry, feature_entry)
+        mock_query.assert_called_with(sequence.Feature, organism_id=11, uniquename="testseqid")
+        mock_create.assert_called_with(self.default_gff_entry, 1, 2)
+        mock_insert.assert_called()
+        self.assertIsNotNone(featureloc_entry)
+
+        mock_query.return_value = None
+        featureloc_entry = self.client._handle_location(self.default_gff_entry, feature_entry)
+        self.assertIsNone(featureloc_entry)
+
+    @unittest.mock.patch("pychado.io.gff.GFFImportClient._handle_feature_synonym")
+    @unittest.mock.patch("pychado.orm.sequence.FeatureSynonym")
+    @unittest.mock.patch("pychado.io.gff.GFFImportClient._handle_synonym")
+    @unittest.mock.patch("pychado.orm.sequence.Synonym")
+    @unittest.mock.patch("pychado.io.gff.GFFImportClient.query_all")
+    def test_handle_synonyms(self, mock_query: unittest.mock.Mock, mock_synonym: unittest.mock.Mock,
+                             mock_insert_synonym: unittest.mock.Mock, mock_feature_synonym: unittest.mock.Mock,
+                             mock_insert_feature_synonym: unittest.mock.Mock):
+        # Tests the function transferring data from a GFF file entry to the 'feature_synonym' table
+        self.assertIs(mock_query, self.client.query_all)
+        self.assertIs(mock_synonym, sequence.Synonym)
+        self.assertIs(mock_insert_synonym, self.client._handle_synonym)
+        self.assertIs(mock_feature_synonym, sequence.FeatureSynonym)
+        self.assertIs(mock_insert_feature_synonym, self.client._handle_feature_synonym)
+
+        feature_entry = sequence.Feature(organism_id=11, type_id=200, uniquename="testname", feature_id=1)
+        mock_insert_synonym.return_value = utils.EmptyObject(synonym_id=12)
+
+        all_synonyms = self.client._handle_synonyms(self.default_gff_entry, feature_entry)
+        mock_query.assert_called_with(sequence.FeatureSynonym, feature_id=1)
+        mock_synonym.assert_any_call(name="testalias", type_id=self.client._synonym_terms["alias"].cvterm_id,
+                                     synonym_sgml="testalias")
+        self.assertEqual(mock_insert_synonym.call_count, 2)
+        mock_feature_synonym.assert_any_call(synonym_id=12, feature_id=1, pub_id=self.client._default_pub.pub_id,
+                                             is_current=True)
+        mock_feature_synonym.assert_any_call(synonym_id=12, feature_id=1, pub_id=self.client._default_pub.pub_id,
+                                             is_current=False)
+        self.assertEqual(mock_insert_feature_synonym.call_count, 2)
+        self.assertEqual(len(all_synonyms), 2)
+
+    @unittest.mock.patch("pychado.io.gff.GFFImportClient._handle_feature_pub")
+    @unittest.mock.patch("pychado.orm.sequence.FeaturePub")
+    @unittest.mock.patch("pychado.io.gff.GFFImportClient._handle_pub")
+    @unittest.mock.patch("pychado.orm.pub.Pub")
+    @unittest.mock.patch("pychado.io.gff.GFFImportClient.query_all")
+    def test_handle_publications(self, mock_query: unittest.mock.Mock, mock_pub: unittest.mock.Mock,
+                                 mock_insert_pub: unittest.mock.Mock, mock_featurepub: unittest.mock.Mock,
+                                 mock_insert_featurepub: unittest.mock.Mock):
+        # Tests the function transferring data from a GFF file entry to the 'feature_pub' table
+        self.assertIs(mock_query, self.client.query_all)
+        self.assertIs(mock_pub, pub.Pub)
+        self.assertIs(mock_insert_pub, self.client._handle_pub)
+        self.assertIs(mock_featurepub, sequence.FeaturePub)
+        self.assertIs(mock_insert_featurepub, self.client._handle_feature_pub)
+
+        feature_entry = sequence.Feature(organism_id=11, type_id=200, uniquename="testname", feature_id=12)
+        mock_insert_pub.return_value = utils.EmptyObject(pub_id=32, uniquename="")
+
+        all_pubs = self.client._handle_publications(self.default_gff_entry, feature_entry)
+        mock_query.assert_called_with(sequence.FeaturePub, feature_id=12)
+        mock_pub.assert_any_call(uniquename="PMID:12334", type_id=self.client._default_pub.type_id)
+        self.assertEqual(mock_insert_pub.call_count, 1)
+        mock_featurepub.assert_any_call(feature_id=12, pub_id=32)
+        self.assertEqual(mock_insert_featurepub.call_count, 1)
+        self.assertEqual(len(all_pubs), 1)
+
+    @unittest.mock.patch("pychado.io.gff.GFFImportClient._handle_feature_relationship")
+    @unittest.mock.patch("pychado.orm.sequence.FeatureRelationship")
+    @unittest.mock.patch("pychado.io.gff.GFFImportClient.query_all")
+    def test_handle_relationships(self, mock_query: unittest.mock.Mock, mock_relationship: unittest.mock.Mock,
+                                  mock_insert_relationship: unittest.mock.Mock):
+        # Tests the function transferring data from a GFF file entry to the 'feature_relationship' table
+        self.assertIs(mock_query, self.client.query_all)
+        self.assertIs(mock_relationship, sequence.FeatureRelationship)
+        self.assertIs(mock_insert_relationship, self.client._handle_feature_relationship)
+
+        subject_entry = sequence.Feature(organism_id=11, type_id=300, uniquename="testid", feature_id=33)
+        object_entry = sequence.Feature(organism_id=11, type_id=400, uniquename="testparent", feature_id=44)
+        all_features = {subject_entry.uniquename: subject_entry, object_entry.uniquename: object_entry}
+
+        all_relationships = self.client._handle_relationships(self.default_gff_entry, all_features)
+        mock_query.assert_called_with(sequence.FeatureRelationship, subject_id=33)
+        mock_relationship.assert_any_call(subject_id=33, object_id=44,
+                                          type_id=self.client._relationship_terms["part_of"].cvterm_id)
+        self.assertEqual(mock_insert_relationship.call_count, 1)
+        self.assertEqual(len(all_relationships), 1)
+
+    @unittest.mock.patch("pychado.io.gff.GFFImportClient._handle_featureprop")
+    @unittest.mock.patch("pychado.orm.sequence.FeatureProp")
+    @unittest.mock.patch("pychado.io.gff.GFFImportClient.query_all")
+    def test_handle_properties(self, mock_query: unittest.mock.Mock, mock_prop: unittest.mock.Mock,
+                               mock_insert_prop: unittest.mock.Mock):
+        # Tests the function transferring data from a GFF file entry to the 'featureprop' table
+        self.assertIs(mock_query, self.client.query_all)
+        self.assertIs(mock_prop, sequence.FeatureProp)
+        self.assertIs(mock_insert_prop, self.client._handle_featureprop)
+
+        feature_entry = sequence.Feature(organism_id=11, type_id=200, uniquename="testname", feature_id=12)
+        all_properties = self.client._handle_properties(self.default_gff_entry, feature_entry)
+        mock_query.assert_called_with(sequence.FeatureProp, feature_id=12)
+        mock_prop.assert_any_call(feature_id=12, type_id=self.client._feature_property_terms["source"].cvterm_id,
+                                  value="testsource")
+        mock_prop.assert_any_call(feature_id=12, type_id=self.client._feature_property_terms["comment"].cvterm_id,
+                                  value="testnote")
+        mock_prop.assert_any_call(feature_id=12, type_id=self.client._feature_property_terms["score"].cvterm_id,
+                                  value="3.5")
+        self.assertEqual(mock_insert_prop.call_count, 3)
+        self.assertEqual(len(all_properties), 3)
+
+    @unittest.mock.patch("pychado.io.gff.GFFImportClient._handle_feature_dbxref")
+    @unittest.mock.patch("pychado.orm.sequence.FeatureDbxRef")
+    @unittest.mock.patch("pychado.io.gff.GFFImportClient._handle_dbxref")
+    @unittest.mock.patch("pychado.orm.general.DbxRef")
+    @unittest.mock.patch("pychado.io.gff.GFFImportClient._handle_db")
+    @unittest.mock.patch("pychado.orm.general.Db")
+    @unittest.mock.patch("pychado.io.gff.GFFImportClient.query_all")
+    def test_handle_crossrefs(self, mock_query: unittest.mock.Mock, mock_db: unittest.mock.Mock,
+                              mock_insert_db: unittest.mock.Mock, mock_dbxref: unittest.mock.Mock,
+                              mock_insert_dbxref: unittest.mock.Mock, mock_feature_dbxref: unittest.mock.Mock,
+                              mock_insert_feature_dbxref: unittest.mock.Mock):
+        # Tests the function transferring data from a GFF file entry to the 'feature_dbxref' table
+        self.assertIs(mock_query, self.client.query_all)
+        self.assertIs(mock_db, general.Db)
+        self.assertIs(mock_insert_db, self.client._handle_db)
+        self.assertIs(mock_dbxref, general.DbxRef)
+        self.assertIs(mock_insert_dbxref, self.client._handle_dbxref)
+        self.assertIs(mock_feature_dbxref, sequence.FeatureDbxRef)
+        self.assertIs(mock_insert_feature_dbxref, self.client._handle_feature_dbxref)
+
+        feature_entry = sequence.Feature(organism_id=11, type_id=200, uniquename="testname", feature_id=12)
+        mock_insert_db.return_value = utils.EmptyObject(db_id=44, name="")
+        mock_insert_dbxref.return_value = utils.EmptyObject(dbxref_id=55, accession="", version="")
+
+        all_crossrefs = self.client._handle_cross_references(self.default_gff_entry, feature_entry)
+        mock_query.assert_called_with(sequence.FeatureDbxRef, feature_id=12)
+        mock_db.assert_any_call(name="testdb")
+        mock_dbxref.assert_any_call(db_id=44, accession="testaccession", version="")
+        mock_feature_dbxref.assert_any_call(feature_id=12, dbxref_id=55)
+        self.assertEqual(mock_insert_db.call_count, 1)
+        self.assertEqual(mock_insert_dbxref.call_count, 1)
+        self.assertEqual(mock_insert_feature_dbxref.call_count, 1)
+        self.assertEqual(len(all_crossrefs), 1)
+
+    @unittest.mock.patch("pychado.io.gff.GFFImportClient._handle_feature_cvterm")
+    @unittest.mock.patch("pychado.orm.sequence.FeatureCvTerm")
+    @unittest.mock.patch("pychado.io.gff.GFFImportClient.query_first")
+    @unittest.mock.patch("pychado.io.gff.GFFImportClient.query_all")
+    def test_handle_ontology_terms(self, mock_query: unittest.mock.Mock, mock_query_first: unittest.mock.Mock,
+                                   mock_feature_cvterm: unittest.mock.Mock,
+                                   mock_insert_feature_cvterm: unittest.mock.Mock):
+        # Tests the function transferring data from a GFF file entry to the 'feature_cvterm' table
+        self.assertIs(mock_query, self.client.query_all)
+        self.assertIs(mock_query_first, self.client.query_first)
+        self.assertIs(mock_feature_cvterm, sequence.FeatureCvTerm)
+        self.assertIs(mock_insert_feature_cvterm, self.client._handle_feature_cvterm)
+
+        feature_entry = sequence.Feature(organism_id=11, type_id=200, uniquename="testname", feature_id=12)
+        mock_query_first.side_effect = [utils.EmptyObject(db_id=33),
+                                        utils.EmptyObject(dbxref_id=44),
+                                        utils.EmptyObject(cvterm_id=55)]
+
+        all_ontology_terms = self.client._handle_ontology_terms(self.default_gff_entry, feature_entry)
+        mock_query_first.assert_any_call(general.Db, name="GO")
+        mock_query_first.assert_any_call(general.DbxRef, db_id=33, accession="7890")
+        mock_query_first.assert_any_call(cv.CvTerm, dbxref_id=44)
+        self.assertEqual(mock_query_first.call_count, 3)
+        mock_feature_cvterm.assert_any_call(feature_id=12, cvterm_id=55, pub_id=self.client._default_pub.pub_id)
+        self.assertEqual(mock_insert_feature_cvterm.call_count, 1)
+        self.assertEqual(len(all_ontology_terms), 1)
+
+    def test_create_feature(self):
+        # Tests the function that creates an entry for the 'feature' table
+        feature = self.client._create_feature(self.default_gff_entry, 3, 5)
+        self.assertEqual(feature.organism_id, 3)
+        self.assertEqual(feature.type_id, 5)
+        self.assertEqual(feature.uniquename, "testid")
+        self.assertEqual(feature.name, "testname")
+        self.assertEqual(feature.residues, "MCRA")
+        self.assertEqual(feature.seqlen, 4)
+
+    def test_create_featureloc(self):
+        # Tests the function that creates an entry for the 'featureloc' table
+        featureloc = self.client._create_featureloc(self.default_gff_entry, 3, 5)
+        self.assertEqual(featureloc.feature_id, 3)
+        self.assertEqual(featureloc.srcfeature_id, 5)
+        self.assertEqual(featureloc.fmin, 0)
+        self.assertEqual(featureloc.fmax, 30)
+        self.assertEqual(featureloc.strand, 1)
+        self.assertEqual(featureloc.phase, 2)
+
+    def test_extract_name(self):
+        # Tests the function that extracts the name from a GFF file entry
+        feature = gffutils.Feature()
+        name = self.client._extract_name(feature)
+        self.assertIsNone(name)
+        feature.attributes = {"Name": "testname"}
+        name = self.client._extract_name(feature)
+        self.assertEqual(name, "testname")
+        feature.attributes = {"Name": ["othername"]}
+        name = self.client._extract_name(feature)
+        self.assertEqual(name, "othername")
+
+    def test_extract_synonyms(self):
+        # Tests the function that extracts the synonyms from a GFF file entry
+        feature = gffutils.Feature(attributes={"Alias": "testalias", "previous_systematic_id": ["testsynonym"]})
+        synonyms = self.client._extract_synonyms(feature)
+        self.assertEqual(len(synonyms), 2)
+        self.assertEqual(synonyms["alias"], ["testalias"])
+        self.assertEqual(synonyms["previous_systematic_id"], ["testsynonym"])
+
+    def test_extract_residues(self):
+        # Tests the function that extracts an amino acid sequence from a GFF file entry
+        feature = gffutils.Feature()
+        residues = self.client._extract_residues(feature)
+        self.assertIsNone(residues)
+        feature.attributes = {"translation": "actgaa"}
+        residues = self.client._extract_residues(feature)
+        self.assertEqual(residues, "ACTGAA")
+        feature.attributes = {"translation": ["cTTg"]}
+        residues = self.client._extract_residues(feature)
+        self.assertEqual(residues, "CTTG")
+
+    def test_extract_relationships(self):
+        # Tests the function that extracts feature relationships from a GFF file entry
+        feature = gffutils.Feature(attributes={"Parent": "parentterm", "Derives_from": ["otherterm"],
+                                               "other_key": "other_value"})
+        relationships = self.client._extract_relationships(feature)
+        self.assertEqual(len(relationships), 2)
+        self.assertEqual(relationships["part_of"], ["parentterm"])
+        self.assertEqual(relationships["derives_from"], ["otherterm"])
+
+    def test_extract_properties(self):
+        # Tests the function that extracts feature properties from a GFF file entry
+        feature = gffutils.Feature(source="testsource", score="2.54",
+                                   attributes={"Parent": "parentterm", "comment": ["first_value", "second_value"]})
+        properties = self.client._extract_properties(feature)
+        self.assertEqual(len(properties), 3)
+        self.assertEqual(properties["source"], ["testsource"])
+        self.assertEqual(properties["score"], ["2.54"])
+        self.assertEqual(properties["comment"], ["first_value", "second_value"])
+
+    def test_extract_crossrefs(self):
+        # Tests the function that extracts database cross references from a GFF file entry
+        feature = gffutils.Feature(attributes={"Dbxref": "Wikipedia:gene", "Ontology_term": ["GO:12345", "GO:67890"]})
+        crossrefs = self.client._extract_crossrefs(feature)
+        self.assertEqual(len(crossrefs), 1)
+        self.assertIn("Wikipedia:gene", crossrefs)
+
+    def test_extract_ontology_terms(self):
+        # Tests the function that extracts ontology terms from a GFF file entry
+        feature = gffutils.Feature(attributes={"Dbxref": "Wikipedia:gene", "Ontology_term": ["GO:12345", "GO:67890"]})
+        ontology_terms = self.client._extract_ontology_terms(feature)
+        self.assertEqual(len(ontology_terms), 2)
+        self.assertIn("GO:67890", ontology_terms)
+
+    def test_extract_publications(self):
+        # Tests the function that extracts publications from a GFF file entry
+        feature = gffutils.Feature(attributes={"literature": "PMID:12345"})
+        publications = self.client._extract_publications(feature)
+        self.assertEqual(len(publications), 1)
+        self.assertIn("PMID:12345", publications)
+
+    def test_convert_strand(self):
+        # Tests the function converting the 'strand' attribute from string notation to integer notation
+        gff_strand = "+"
+        chado_strand = gff.convert_strand(gff_strand)
+        self.assertEqual(chado_strand, 1)
+        gff_strand = "-"
+        chado_strand = gff.convert_strand(gff_strand)
+        self.assertEqual(chado_strand, -1)
+        gff_strand = "something_elsa"
+        chado_strand = gff.convert_strand(gff_strand)
+        self.assertIsNone(chado_strand)
+
+    def test_convert_frame(self):
+        # Tests the function converting the 'frame' attribute from string notation to integer notation
+        gff_frame = "."
+        chado_frame = gff.convert_frame(gff_frame)
+        self.assertIsNone(chado_frame)
+        gff_frame = "2"
+        chado_frame = gff.convert_frame(gff_frame)
+        self.assertEqual(chado_frame, 2)
+        gff_frame = "3"
+        chado_frame = gff.convert_frame(gff_frame)
+        self.assertIsNone(chado_frame)
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2, buffer=True)

--- a/pychado/tests/orm_tests.py
+++ b/pychado/tests/orm_tests.py
@@ -3,7 +3,7 @@ import sqlalchemy.exc
 import sqlalchemy.schema
 from .. import dbutils, utils
 from ..io import iobase
-from ..orm import base, general, cv, organism, pub, sequence, audit
+from ..orm import base, general, cv, organism, pub, sequence, companalysis, audit
 
 
 class TestPublic(unittest.TestCase):
@@ -1448,7 +1448,111 @@ class TestPublic(unittest.TestCase):
         with self.assertRaises(sqlalchemy.exc.IntegrityError):
             self.client.add_and_flush(obj)
 
-            
+    # Test suite for the Chado 'analysis' table
+    def add_analysis_object(self) -> companalysis.Analysis:
+        # Insert a random entry into the 'analysis' table
+        analysis_obj = companalysis.Analysis(program=utils.random_string(10), programversion=utils.random_string(10),
+                                             name=utils.random_string(10), description=utils.random_string(10),
+                                             algorithm=utils.random_string(10), sourcename=utils.random_string(10),
+                                             sourceversion=utils.random_string(10), sourceuri=utils.random_string(10))
+        self.client.add_and_flush(analysis_obj)
+        return analysis_obj
+
+    def test_analysis(self):
+        # Test adding a new 'analysis' object to the database
+        existing_obj = self.add_analysis_object()
+        self.assertIsNotNone(existing_obj.analysis_id)
+        self.assertEqual(existing_obj.__tablename__, 'analysis')
+
+    def test_analysis_c1(self):
+        # Test unique constraint on 'analysis.program', 'analysis.programversion', 'analysis.sourcename'
+        existing_obj = self.add_analysis_object()
+        obj = companalysis.Analysis(program=existing_obj.program, programversion=existing_obj.programversion,
+                                    sourcename=existing_obj.sourcename)
+        with self.assertRaises(sqlalchemy.exc.IntegrityError):
+            self.client.add_and_flush(obj)
+
+    # Test suite for the Chado 'analysisfeature' table
+    def add_analysisfeature_object(self) -> companalysis.AnalysisFeature:
+        # Insert a random entry into the 'analysisfeature' table
+        analysis_obj = self.add_analysis_object()
+        feature_obj = self.add_feature_object()
+        analysisfeature_obj = companalysis.AnalysisFeature(
+            feature_id=feature_obj.feature_id, analysis_id=analysis_obj.analysis_id, rawscore=utils.random_float(),
+            normscore=utils.random_float(), significance=utils.random_float(), identity=utils.random_float())
+        self.client.add_and_flush(analysisfeature_obj)
+        return analysisfeature_obj
+
+    def test_analysisfeature(self):
+        # Test adding a new 'analysisfeature' object to the database
+        existing_obj = self.add_analysisfeature_object()
+        self.assertIsNotNone(existing_obj.analysisfeature_id)
+        self.assertEqual(existing_obj.__tablename__, 'analysisfeature')
+
+    def test_analysisfeature_feature_id_fkey(self):
+        # Test foreign key constraint on 'analysisfeature.feature_id'
+        existing_obj = self.add_analysisfeature_object()
+        obj = companalysis.AnalysisFeature(feature_id=(existing_obj.feature_id+100),
+                                           analysis_id=existing_obj.analysis_id)
+        with self.assertRaises(sqlalchemy.exc.IntegrityError):
+            self.client.add_and_flush(obj)
+
+    def test_analysisfeature_analysis_id_fkey(self):
+        # Test foreign key constraint on 'analysisfeature.analysis_id'
+        existing_obj = self.add_analysisfeature_object()
+        obj = companalysis.AnalysisFeature(feature_id=existing_obj.feature_id,
+                                           analysis_id=(existing_obj.analysis_id+100))
+        with self.assertRaises(sqlalchemy.exc.IntegrityError):
+            self.client.add_and_flush(obj)
+
+    def test_analysisfeature_c1(self):
+        # Test unique constraint on 'analysisfeature.feature_id', 'analysisfeature.analysis_id'
+        existing_obj = self.add_analysisfeature_object()
+        obj = companalysis.AnalysisFeature(feature_id=existing_obj.feature_id, analysis_id=existing_obj.analysis_id)
+        with self.assertRaises(sqlalchemy.exc.IntegrityError):
+            self.client.add_and_flush(obj)
+
+    # Test suite for the Chado 'analysisprop' table
+    def add_analysisprop_object(self) -> companalysis.AnalysisProp:
+        # Insert a random entry into the 'analysisprop' table
+        analysis_obj = self.add_analysis_object()
+        type_obj = self.add_cvterm_object()
+        analysisprop_obj = companalysis.AnalysisProp(analysis_id=analysis_obj.analysis_id, type_id=type_obj.cvterm_id,
+                                                     value=utils.random_string(10))
+        self.client.add_and_flush(analysisprop_obj)
+        return analysisprop_obj
+
+    def test_analysisprop(self):
+        # Test adding a new 'analysisprop' object to the database
+        existing_obj = self.add_analysisprop_object()
+        self.assertIsNotNone(existing_obj.analysisprop_id)
+        self.assertEqual(existing_obj.__tablename__, 'analysisprop')
+
+    def test_analysisprop_analysis_id_fkey(self):
+        # Test foreign key constraint on 'analysisprop.analysis_id'
+        existing_obj = self.add_analysisprop_object()
+        obj = companalysis.AnalysisProp(analysis_id=(existing_obj.analysis_id+100), type_id=existing_obj.type_id,
+                                        value=utils.random_string(10))
+        with self.assertRaises(sqlalchemy.exc.IntegrityError):
+            self.client.add_and_flush(obj)
+
+    def test_analysisprop_type_id_fkey(self):
+        # Test foreign key constraint on 'analysisprop.type_id'
+        existing_obj = self.add_analysisprop_object()
+        obj = companalysis.AnalysisProp(analysis_id=existing_obj.analysis_id, type_id=(existing_obj.type_id+100),
+                                        value=utils.random_string(10))
+        with self.assertRaises(sqlalchemy.exc.IntegrityError):
+            self.client.add_and_flush(obj)
+
+    def test_analysisprop_c1(self):
+        # Test unique constraint on 'analysisprop.analysis_id', 'analysisprop.type_id', 'analysisprop.value'
+        existing_obj = self.add_analysisprop_object()
+        obj = companalysis.AnalysisProp(analysis_id=existing_obj.analysis_id, type_id=existing_obj.type_id,
+                                        value=existing_obj.value)
+        with self.assertRaises(sqlalchemy.exc.IntegrityError):
+            self.client.add_and_flush(obj)
+
+
 class TestAudit(unittest.TestCase):
     """Base class for testing the setup of the master table defined in the 'audit' schema of the ORM"""
 

--- a/pychado/tests/tasks_tests.py
+++ b/pychado/tests/tasks_tests.py
@@ -1,6 +1,6 @@
 import unittest.mock
 from .. import chado_tools, tasks, queries, dbutils, utils, ddl
-from ..io import direct, ontology
+from ..io import direct, essentials, ontology, gff
 
 
 class TestTasks(unittest.TestCase):
@@ -125,12 +125,12 @@ class TestTasks(unittest.TestCase):
     @unittest.mock.patch('pychado.ddl.PublicSchemaSetupClient')
     @unittest.mock.patch('pychado.utils.download_file')
     @unittest.mock.patch('pychado.dbutils.setup_database')
-    def test_setup(self, mock_setup, mock_download, mock_create_public_schema, mock_create_audit_schema):
+    def test_setup(self, mock_setup, mock_download, mock_public_schema_client, mock_audit_schema_client):
         # Checks that the function setting up a database schema is correctly called
         self.assertIs(mock_setup, dbutils.setup_database)
         self.assertIs(mock_download, utils.download_file)
-        self.assertIs(mock_create_public_schema, ddl.PublicSchemaSetupClient)
-        self.assertIs(mock_create_audit_schema, ddl.AuditSchemaSetupClient)
+        self.assertIs(mock_public_schema_client, ddl.PublicSchemaSetupClient)
+        self.assertIs(mock_audit_schema_client, ddl.AuditSchemaSetupClient)
 
         args = ["chado", "admin", "setup", "-f", "testschema", "testdb"]
         parsed_args = chado_tools.parse_arguments(args)
@@ -146,23 +146,23 @@ class TestTasks(unittest.TestCase):
         mock_download.assert_called()
         mock_setup.assert_called_with(self.uri, "downloaded_schema")
 
-        mock_create_public_schema.reset_mock()
-        mock_create_audit_schema.reset_mock()
+        mock_public_schema_client.reset_mock()
+        mock_audit_schema_client.reset_mock()
         args = ["chado", "admin", "setup", "-s", "basic", "testdb"]
         parsed_args = chado_tools.parse_arguments(args)
         tasks.run_setup_command(parsed_args, self.uri)
-        mock_create_public_schema.assert_called_with(self.uri)
-        self.assertIn(unittest.mock.call().create(), mock_create_public_schema.mock_calls)
-        mock_create_audit_schema.assert_not_called()
+        mock_public_schema_client.assert_called_with(self.uri)
+        self.assertIn(unittest.mock.call().create(), mock_public_schema_client.mock_calls)
+        mock_audit_schema_client.assert_not_called()
 
-        mock_create_public_schema.reset_mock()
-        mock_create_audit_schema.reset_mock()
+        mock_public_schema_client.reset_mock()
+        mock_audit_schema_client.reset_mock()
         args = ["chado", "admin", "setup", "-s", "audit", "testdb"]
         parsed_args = chado_tools.parse_arguments(args)
         tasks.run_setup_command(parsed_args, self.uri)
-        mock_create_public_schema.assert_not_called()
-        mock_create_audit_schema.assert_called_with(self.uri)
-        self.assertIn(unittest.mock.call().create(), mock_create_audit_schema.mock_calls)
+        mock_public_schema_client.assert_not_called()
+        mock_audit_schema_client.assert_called_with(self.uri)
+        self.assertIn(unittest.mock.call().create(), mock_audit_schema_client.mock_calls)
 
     @unittest.mock.patch('pychado.tasks.run_grant_revoke_command')
     def test_run_grant(self, mock_run):
@@ -179,26 +179,26 @@ class TestTasks(unittest.TestCase):
         mock_run.assert_called_with(parsed_args, self.uri, False)
 
     @unittest.mock.patch('pychado.ddl.RolesClient')
-    def test_grant(self, mock_grant):
+    def test_grant(self, mock_client):
         # Checks that the function granting database access is correctly called
-        self.assertIs(mock_grant, ddl.RolesClient)
+        self.assertIs(mock_client, ddl.RolesClient)
         args = ["chado", "admin", "grant", "-r", "testrole", "-s", "testschema", "-w", "testdb"]
         parsed_args = chado_tools.parse_arguments(args)
         tasks.run_grant_revoke_command(parsed_args, self.uri, True)
-        mock_grant.assert_called_with(self.uri)
+        mock_client.assert_called_with(self.uri)
         self.assertIn(unittest.mock.call().grant_or_revoke("testrole", "testschema", True, True),
-                      mock_grant.mock_calls)
+                      mock_client.mock_calls)
 
     @unittest.mock.patch('pychado.ddl.RolesClient')
-    def test_revoke(self, mock_grant):
+    def test_revoke(self, mock_client):
         # Checks that the function revoking database access is correctly called
-        self.assertIs(mock_grant, ddl.RolesClient)
+        self.assertIs(mock_client, ddl.RolesClient)
         args = ["chado", "admin", "revoke", "-r", "testrole", "-s", "testschema", "testdb"]
         parsed_args = chado_tools.parse_arguments(args)
         tasks.run_grant_revoke_command(parsed_args, self.uri, False)
-        mock_grant.assert_called_with(self.uri)
+        mock_client.assert_called_with(self.uri)
         self.assertIn(unittest.mock.call().grant_or_revoke("testrole", "testschema", False, False),
-                      mock_grant.mock_calls)
+                      mock_client.mock_calls)
 
     @unittest.mock.patch('pychado.utils.read_text')
     @unittest.mock.patch('pychado.dbutils.query_to_file')
@@ -333,66 +333,91 @@ class TestTasks(unittest.TestCase):
         tasks.run_command_with_arguments(args[1], args[2], parsed_args, self.uri)
         mock_run.assert_called_with("organism", parsed_args, self.uri)
 
-    @unittest.mock.patch('pychado.io.direct.DirectIOClient.insert_organism')
-    def test_insert_organism(self, mock_insert):
+    @unittest.mock.patch('pychado.io.direct.DirectIOClient')
+    def test_insert_organism(self, mock_client):
         # Checks that the function inserting organisms is correctly called
-        self.assertIs(mock_insert, direct.DirectIOClient.insert_organism)
+        self.assertIs(mock_client, direct.DirectIOClient)
         args = ["chado", "insert", "organism", "-g", "testgenus", "-s", "testspecies", "-a", "testorganism", "testdb"]
         parsed_args = chado_tools.parse_arguments(args)
 
         tasks.run_insert_command(args[2], parsed_args, self.uri)
-        mock_insert.assert_called_with("testgenus", "testspecies", "testorganism", None, None, None)
+        mock_client.assert_called_with(self.uri)
+        self.assertIn(unittest.mock.call().insert_organism("testgenus", "testspecies", "testorganism",
+                                                           None, None, None), mock_client.mock_calls)
 
-        mock_insert.reset_mock()
+        mock_client.reset_mock()
         tasks.run_insert_command("inexistent_specifier", parsed_args, self.uri)
-        mock_insert.assert_not_called()
+        self.assertEqual([unittest.mock.call(self.uri)], mock_client.mock_calls)
 
-    @unittest.mock.patch('pychado.io.direct.DirectIOClient.delete_organism')
-    def test_delete_organism(self, mock_delete):
+    @unittest.mock.patch('pychado.io.direct.DirectIOClient')
+    def test_delete_organism(self, mock_client):
         # Checks that the function inserting organisms is correctly called
-        self.assertIs(mock_delete, direct.DirectIOClient.delete_organism)
+        self.assertIs(mock_client, direct.DirectIOClient)
         args = ["chado", "delete", "organism", "-a", "testorganism", "testdb"]
         parsed_args = chado_tools.parse_arguments(args)
 
         tasks.run_delete_command(args[2], parsed_args, self.uri)
-        mock_delete.assert_called_with("testorganism")
+        mock_client.assert_called_with(self.uri)
+        self.assertIn(unittest.mock.call().delete_organism("testorganism"), mock_client.mock_calls)
 
-        mock_delete.reset_mock()
+        mock_client.reset_mock()
         tasks.run_delete_command("inexistent_specifier", parsed_args, self.uri)
-        mock_delete.assert_not_called()
+        self.assertEqual([unittest.mock.call(self.uri)], mock_client.mock_calls)
 
     @unittest.mock.patch('pychado.tasks.run_import_command')
     def test_run_import(self, mock_run):
         # Checks that database imports are correctly run
         self.assertIs(mock_run, tasks.run_import_command)
-        args = ["chado", "import", "ontology", "-f", "testfile", "-A", "testauthority", "-F", "owl", "testdb"]
+        args = ["chado", "import", "essentials", "testdb"]
         parsed_args = chado_tools.parse_arguments(args)
         tasks.run_command_with_arguments(args[1], args[2], parsed_args, self.uri)
-        mock_run.assert_called_with("ontology", parsed_args, self.uri)
+        mock_run.assert_called_with("essentials", parsed_args, self.uri)
+
+    @unittest.mock.patch('pychado.io.essentials.EssentialsClient')
+    def test_import_essentials(self, mock_client):
+        # Checks that the function importing essentials into the database is correctly called
+        self.assertIs(mock_client, essentials.EssentialsClient)
+        args = ["chado", "import", "essentials", "testdb"]
+        parsed_args = chado_tools.parse_arguments(args)
+        tasks.run_import_command(args[2], parsed_args, self.uri)
+        mock_client.assert_called_with(self.uri, False)
+        self.assertIn(unittest.mock.call().load(), mock_client.mock_calls)
+
+        mock_client.reset_mock()
+        tasks.run_import_command("inexistent_specifier", parsed_args, self.uri)
+        mock_client.assert_not_called()
 
     @unittest.mock.patch('pychado.utils.download_file')
-    @unittest.mock.patch('pychado.io.ontology.OntologyClient.load')
-    def test_import_ontology(self, mock_import, mock_download):
+    @unittest.mock.patch('pychado.io.ontology.OntologyClient')
+    def test_import_ontology(self, mock_client, mock_download):
         # Checks that the function importing an ontology into the database is correctly called
-        self.assertIs(mock_import, ontology.OntologyClient.load)
+        self.assertIs(mock_client, ontology.OntologyClient)
         self.assertIs(mock_download, utils.download_file)
         args = ["chado", "import", "ontology", "-f", "testfile", "-A", "testauthority", "-F", "owl", "testdb"]
         parsed_args = chado_tools.parse_arguments(args)
         tasks.run_import_command(args[2], parsed_args, self.uri)
         mock_download.assert_not_called()
-        mock_import.assert_called_with("testfile", "owl", "testauthority")
+        mock_client.assert_called_with(self.uri, False)
+        self.assertIn(unittest.mock.call().load("testfile", "owl", "testauthority"), mock_client.mock_calls)
 
-        mock_download.reset_mock()
+        mock_client.reset_mock()
         mock_download.return_value = "downloaded_file"
-        args = ["chado", "import", "ontology", "-u", "testurl", "-A", "testauthority", "testdb"]
+        args = ["chado", "import", "ontology", "-V", "-u", "testurl", "-A", "testauthority", "testdb"]
         parsed_args = chado_tools.parse_arguments(args)
         tasks.run_import_command(args[2], parsed_args, self.uri)
         mock_download.assert_called_with("testurl")
-        mock_import.assert_called_with("downloaded_file", "obo", "testauthority")
+        mock_client.assert_called_with(self.uri, True)
+        self.assertIn(unittest.mock.call().load("downloaded_file", "obo", "testauthority"), mock_client.mock_calls)
 
-        mock_import.reset_mock()
-        tasks.run_import_command("inexistent_specifier", parsed_args, self.uri)
-        mock_import.assert_not_called()
+    @unittest.mock.patch('pychado.io.gff.GFFImportClient')
+    def test_import_gff(self, mock_client):
+        # Checks that the function importing a GFF file into the database is correctly called
+        self.assertIs(mock_client, gff.GFFImportClient)
+        args = ["chado", "import", "gff", "-f", "testfile", "-a", "testorganism", "testdb"]
+        parsed_args = chado_tools.parse_arguments(args)
+        tasks.run_import_command(args[2], parsed_args, self.uri)
+        mock_client.assert_called_with(self.uri, False)
+        self.assertIn(unittest.mock.call().load("testfile", "testorganism"), mock_client.mock_calls)
 
 
 if __name__ == '__main__':

--- a/pychado/tests/utils_tests.py
+++ b/pychado/tests/utils_tests.py
@@ -121,6 +121,14 @@ class TestUtils(unittest.TestCase):
         int2 = utils.random_integer(10000)
         self.assertNotEqual(int1, int2)
 
+    def test_random_float(self):
+        # tests if a function generates a random float number between 0 and 1
+        float1 = utils.random_float()
+        self.assertGreaterEqual(float1, 0.0)
+        self.assertLessEqual(float1, 1.0)
+        float2 = utils.random_float()
+        self.assertFalse(abs(float1 - float2) < 0.00001)
+
     def test_current_date(self):
         # checks if a function returns the current date in the correct format
         date = utils.current_date()

--- a/pychado/tests/utils_tests.py
+++ b/pychado/tests/utils_tests.py
@@ -92,6 +92,20 @@ class TestUtils(unittest.TestCase):
         with self.assertRaises(AttributeError):
             utils.filter_objects(persons, heads=2)
 
+    def test_copy_attributes(self):
+        # checks if a function correctly copies attributes from one object to another
+        john = utils.EmptyObject(name="John", age=42, sex="m")
+        mike = utils.EmptyObject(name="Mike", age=23, sex="m")
+        updated = utils.copy_attribute(john, mike, "age")
+        self.assertTrue(updated)
+        self.assertEqual(getattr(john, "age"), 23)
+        updated = utils.copy_attribute(john, mike, "sex")
+        self.assertFalse(updated)
+        updated = utils.copy_attribute("abc", "def", "xyz")
+        self.assertFalse(updated)
+        updated = utils.copy_attribute("abc", 567, "xyz")
+        self.assertFalse(updated)
+
     def test_list_to_dict(self):
         # checks if a function correctly converts a list into a dictionary
         john = utils.EmptyObject(name="John")

--- a/pychado/utils.py
+++ b/pychado/utils.py
@@ -141,6 +141,16 @@ def filter_objects(entries: list, **kwargs) -> list:
     return filtered_entries
 
 
+def copy_attribute(old_object, new_object, attribute: str) -> bool:
+    """Copies the value of a given attribute from one object to another"""
+    new_value = getattr(new_object, attribute, None)
+    old_value = getattr(old_object, attribute, None)
+    if type(old_object) == type(new_object) and new_value is not None and old_value != new_value:
+        setattr(old_object, attribute, new_value)
+        return True
+    return False
+
+
 def list_to_dict(entries: list, key: str) -> dict:
     """Converts a list of objects of any type into a dictionary, using a specified object parameter as key"""
     dictionary = {}

--- a/pychado/utils.py
+++ b/pychado/utils.py
@@ -160,6 +160,16 @@ def random_integer(n: int) -> int:
     return random.randint(0, n)
 
 
+def random_float() -> float:
+    """Generates a random positive float number between 0 and 1"""
+    n1 = random_integer(1000) + 1
+    n2 = random_integer(1000) + 1
+    if n2 > n1:
+        return float(n1)/float(n2)
+    else:
+        return float(n2)/float(n1)
+
+
 def current_date() -> str:
     """Function returning the current date in format 'YYYYMMDD"""
     return datetime.date.today().strftime('%Y%m%d')

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ except FileNotFoundError or FileExistsError:
 
 setuptools.setup(
     name="chado-tools",
-    version="0.1.2",
+    version="0.1.3",
     author="Christoph Puethe",
     author_email="path-help@sanger.ac.uk",
     description="Tools to access CHADO databases",
@@ -42,7 +42,8 @@ setuptools.setup(
         "sqlalchemy-utils",
         "psycopg2-binary",
         "pyyaml",
-        "pronto >= 0.11.0"
+        "pronto >= 0.11.0",
+        "gffutils"
     ],
     license="GPLv3",
     classifiers=[


### PR DESCRIPTION
- ORM for Chado 'companalysis' module, see [here](http://gmod.org/wiki/Chado_Companalysis_Module)
- 'chado import essentials': Functionality to load essential entries into the database tables that aren't part of any known ontology, but needed for e.g. GFF import
- 'chado import gff': Basic functionality for loading the content of GFF files into Chado tables, using the same tables as Artemis
- two additional helper functions in 'utils'
- unit tests for all changes