### PR TITLE
Gff3

### DIFF
--- a/pychado/chado_tools.py
+++ b/pychado/chado_tools.py
@@ -390,6 +390,12 @@ def add_import_gff_arguments(parser: argparse.ArgumentParser):
     parser.add_argument("-a", "--abbreviation", required=True, dest="organism",
                         help="abbreviation/short name of the organism")
     parser.add_argument("--fasta", help="FASTA input file with sequences")
+    parser.add_argument("--fresh_load", action="store_true",
+                        help="load a genome from scratch (default: load an update to an existing genome)")
+    parser.add_argument("--force", action="store_true",
+                        help="in case of a fresh load, purge all existing features of the organism")
+    parser.add_argument("--full_genome", action="store_true",
+                        help="in case of an update, assume that the GFF file contains all features of the organism")
 
 
 def add_import_fasta_arguments(parser: argparse.ArgumentParser):

--- a/pychado/io/iobase.py
+++ b/pychado/io/iobase.py
@@ -59,6 +59,37 @@ class IOClient(ddl.ChadoClient):
             entry = self.insert_into_table(table, **kwargs)
         return entry
 
+    def query_feature_relationship_by_type(self, subject_id: int, types: List[str]) -> sqlalchemy.orm.Query:
+        """Creates a query to select entries with specific 'type_id' from the feature_relationship table"""
+        return self.session.query(sequence.FeatureRelationship)\
+            .join(cv.CvTerm, sequence.FeatureRelationship.type)\
+            .filter(sequence.FeatureRelationship.subject_id == subject_id)\
+            .filter(cv.CvTerm.name.in_(types))
+
+    def query_featureprop_by_type(self, feature_id: int, types: List[str]) -> sqlalchemy.orm.Query:
+        """Creates a query to select entries with specific 'type_id' from the featureprop table"""
+        return self.session.query(sequence.FeatureProp)\
+            .join(cv.CvTerm, sequence.FeatureProp.type)\
+            .filter(sequence.FeatureProp.feature_id == feature_id)\
+            .filter(cv.CvTerm.name.in_(types))
+
+    def query_feature_synonym_by_type(self, feature_id: int, types: List[str]) -> sqlalchemy.orm.Query:
+        """Creates a query to select entries related to a specific 'synonym.type_id' from the feature_synonym table"""
+        return self.session.query(sequence.FeatureSynonym)\
+            .join(sequence.Synonym, sequence.FeatureSynonym.synonym)\
+            .join(cv.CvTerm, sequence.Synonym.type)\
+            .filter(sequence.FeatureSynonym.feature_id == feature_id)\
+            .filter(cv.CvTerm.name.in_(types))
+
+    def query_feature_cvterm_by_ontology(self, feature_id: int, ontologies: List[str]) -> sqlalchemy.orm.Query:
+        """Creates a query to select entries related to a specific 'db.name' from the feature_cvterm table"""
+        return self.session.query(sequence.FeatureCvTerm)\
+            .join(cv.CvTerm, sequence.FeatureCvTerm.cvterm)\
+            .join(general.DbxRef, cv.CvTerm.dbxref)\
+            .join(general.Db, general.DbxRef.db)\
+            .filter(sequence.FeatureCvTerm.feature_id == feature_id)\
+            .filter(general.Db.name.in_(ontologies))
+
 
 class ImportClient(IOClient):
     """Base class for importing data into a CHADO database"""
@@ -104,6 +135,14 @@ class ImportClient(IOClient):
         if not organism_entry:
             raise DatabaseError("Organism '" + organism_name + "' not present in database")
         return organism_entry
+
+    def _load_feature_ids(self, organism_entry: organism.Organism) -> List[str]:
+        """Returns the IDs of all features for a given organism present in the database"""
+        all_feature_ids = []
+        for feature_id, in self.session.query(sequence.Feature.uniquename).filter_by(
+                organism_id=organism_entry.organism_id):
+            all_feature_ids.append(feature_id)
+        return all_feature_ids
 
     def _handle_db(self, new_entry: general.Db) -> general.Db:
         """Inserts or updates an entry in the 'db' table, and returns it"""
@@ -177,26 +216,6 @@ class ImportClient(IOClient):
                 self.printer.print("Inserted term '" + new_entry.name + "' in vocabulary '" + vocabulary + "'")
                 return new_entry
 
-    def _handle_feature_dbxref(self, new_entry: sequence.FeatureDbxRef, existing_entries: List[sequence.FeatureDbxRef],
-                               crossref="", feature="") -> sequence.FeatureDbxRef:
-        """Inserts or updates an entry in the 'feature_dbxref' table, and returns it"""
-
-        # Check if the feature_dbxref is already present in the database
-        matching_entries = utils.filter_objects(existing_entries, dbxref_id=new_entry.dbxref_id)
-        if matching_entries:
-
-            # Check if the entries in database and file have the same properties (there can only be one)
-            matching_entry = matching_entries[0]
-            if self.update_feature_dbxref_properties(matching_entry, new_entry):
-                self.printer.print("Updated cross reference '" + crossref + "' for feature '" + feature + "'")
-            return matching_entry
-        else:
-
-            # Insert new feature_dbxref entry
-            self.add_and_flush(new_entry)
-            self.printer.print("Inserted cross reference '" + crossref + "' for feature '" + feature + "'")
-            return new_entry
-
     def _handle_feature(self, new_entry: sequence.Feature, organism_name="") -> sequence.Feature:
         """Inserts or updates an entry in the 'feature' table and returns it"""
 
@@ -217,7 +236,7 @@ class ImportClient(IOClient):
             self.printer.print("Inserted feature '" + new_entry.uniquename + "' for organism '" + organism_name + "'")
             return new_entry
 
-    def _handle_featureloc(self, new_entry: sequence.FeatureLoc, feature="") -> sequence.FeatureLoc:
+    def _handle_featureloc(self, new_entry: sequence.FeatureLoc, feature_name="") -> sequence.FeatureLoc:
         """Inserts or updates an entry in the 'featureloc' table, and returns it"""
 
         # Check if the featureloc is already present in the database
@@ -226,17 +245,17 @@ class ImportClient(IOClient):
 
             # Check if the entries in database and file have the same properties, and update if not
             if self.update_featureloc_properties(existing_entry, new_entry):
-                self.printer.print("Updated featureloc for feature '" + feature + "'")
+                self.printer.print("Updated featureloc for feature '" + feature_name + "'")
             return existing_entry
         else:
 
             # Insert new featureloc entry
             self.add_and_flush(new_entry)
-            self.printer.print("Inserted featureloc for feature '" + feature + "'")
+            self.printer.print("Inserted featureloc for feature '" + feature_name + "'")
             return new_entry
 
     def _handle_featureprop(self, new_entry: sequence.FeatureProp, existing_entries: List[sequence.FeatureProp],
-                            property_name="", value="", feature="") -> sequence.FeatureProp:
+                            property_name="", value="", feature_name="") -> sequence.FeatureProp:
         """Inserts or updates an entry in the 'featureprop' table, and returns it"""
 
         # Check if the featureprop is already present in the database
@@ -257,11 +276,76 @@ class ImportClient(IOClient):
             # Insert new featureprop entry
             self.add_and_flush(new_entry)
             self.printer.print("Inserted property '" + property_name + "' = '" + value + "' for feature '"
-                               + feature + "'")
+                               + feature_name + "'")
             return new_entry
 
+    def _delete_featureprop(self, new_entries: List[sequence.FeatureProp],
+                            existing_entries: List[sequence.FeatureProp], feature_name=""
+                            ) -> List[sequence.FeatureProp]:
+        """Deletes entries from the 'featureprop' table"""
+
+        # Loop over all entries in the database
+        deleted_entries = []
+        for existing_entry in existing_entries:
+
+            # Check if the entry is also present in the file
+            matching_entries = utils.filter_objects(new_entries, type_id=existing_entry.type_id,
+                                                    rank=existing_entry.rank)
+            if not matching_entries:
+
+                # Delete the entry from the database
+                self.session.delete(existing_entry)
+                deleted_entries.append(existing_entry)
+                type_entry = self.query_first(cv.CvTerm, cvterm_id=existing_entry.type_id)
+                self.printer.print("Deleted property '" + type_entry.name + "' = '" + existing_entry.value
+                                   + "' for feature '" + feature_name + "'")
+
+        return deleted_entries
+
+    def _handle_feature_dbxref(self, new_entry: sequence.FeatureDbxRef, existing_entries: List[sequence.FeatureDbxRef],
+                               crossref="", feature_name="") -> sequence.FeatureDbxRef:
+        """Inserts or updates an entry in the 'feature_dbxref' table, and returns it"""
+
+        # Check if the feature_dbxref is already present in the database
+        matching_entries = utils.filter_objects(existing_entries, dbxref_id=new_entry.dbxref_id)
+        if matching_entries:
+
+            # Check if the entries in database and file have the same properties (there can only be one)
+            matching_entry = matching_entries[0]
+            if self.update_feature_dbxref_properties(matching_entry, new_entry):
+                self.printer.print("Updated cross reference '" + crossref + "' for feature '" + feature_name + "'")
+            return matching_entry
+        else:
+
+            # Insert new feature_dbxref entry
+            self.add_and_flush(new_entry)
+            self.printer.print("Inserted cross reference '" + crossref + "' for feature '" + feature_name + "'")
+            return new_entry
+
+    def _delete_feature_dbxref(self, new_entries: List[sequence.FeatureDbxRef],
+                               existing_entries: List[sequence.FeatureDbxRef], feature_name=""
+                               ) -> List[sequence.FeatureDbxRef]:
+        """Deletes entries from the 'feature_dbxref' table"""
+
+        # Loop over all entries in the database
+        deleted_entries = []
+        for existing_entry in existing_entries:
+
+            # Check if the entry is also present in the file
+            matching_entries = utils.filter_objects(new_entries, dbxref_id=existing_entry.dbxref_id)
+            if not matching_entries:
+                # Delete the entry from the database
+                self.session.delete(existing_entry)
+                deleted_entries.append(existing_entry)
+                dbxref_entry = self.query_first(general.DbxRef, dbxref_id=existing_entry.dbxref_id)
+                db_entry = self.query_first(general.Db, db_id=dbxref_entry.db_id)
+                crossref = db_entry.name + ":" + dbxref_entry.accession
+                self.printer.print("Deleted cross reference '" + crossref + "' for feature '" + feature_name + "'")
+
+        return deleted_entries
+
     def _handle_feature_cvterm(self, new_entry: sequence.FeatureCvTerm, existing_entries: List[sequence.FeatureCvTerm],
-                               term="", feature="") -> sequence.FeatureCvTerm:
+                               term="", feature_name="") -> sequence.FeatureCvTerm:
         """Inserts or updates an entry in the 'feature_cvterm' table, and returns it"""
 
         # Check if the feature_cvterm is already present in the database
@@ -275,8 +359,30 @@ class ImportClient(IOClient):
 
             # Insert new feature_cvterm entry
             self.add_and_flush(new_entry)
-            self.printer.print("Inserted CV term '" + term + "' for feature '" + feature + "'")
+            self.printer.print("Inserted CV term '" + term + "' for feature '" + feature_name + "'")
             return new_entry
+
+    def _delete_feature_cvterm(self, new_entries: List[sequence.FeatureCvTerm],
+                               existing_entries: List[sequence.FeatureCvTerm], feature_name=""
+                               ) -> List[sequence.FeatureCvTerm]:
+        """Deletes entries from the 'feature_cvterm' table"""
+
+        # Loop over all entries in the database
+        deleted_entries = []
+        for existing_entry in existing_entries:
+
+            # Check if the entry is also present in the file
+            matching_entries = utils.filter_objects(new_entries, cvterm_id=existing_entry.cvterm_id,
+                                                    pub_id=existing_entry.pub_id, rank=existing_entry.rank)
+            if not matching_entries:
+
+                # Delete the entry from the database
+                self.session.delete(existing_entry)
+                deleted_entries.append(existing_entry)
+                cvterm_entry = self.query_first(cv.CvTerm, cvterm_id=existing_entry.cvterm_id)
+                self.printer.print("Deleted CV term '" + cvterm_entry.name + "' for feature '" + feature_name + "'")
+
+        return deleted_entries
 
     def _handle_feature_relationship(self, new_entry: sequence.FeatureRelationship,
                                      existing_entries: List[sequence.FeatureRelationship],
@@ -303,6 +409,30 @@ class ImportClient(IOClient):
                                + object_name + "'")
             return new_entry
 
+    def _delete_feature_relationship(self, new_entries: List[sequence.FeatureRelationship],
+                                     existing_entries: List[sequence.FeatureRelationship], subject_name=""
+                                     ) -> List[sequence.FeatureRelationship]:
+        """Deletes entries from the 'feature_relationship' table"""
+
+        # Loop over all entries in the database
+        deleted_entries = []
+        for existing_entry in existing_entries:
+
+            # Check if the entry is also present in the file
+            matching_entries = utils.filter_objects(new_entries, type_id=existing_entry.type_id,
+                                                    object_id=existing_entry.object_id, rank=existing_entry.rank)
+            if not matching_entries:
+
+                # Delete the entry from the database
+                self.session.delete(existing_entry)
+                deleted_entries.append(existing_entry)
+                object_entry = self.query_first(sequence.Feature, feature_id=existing_entry.object_id)
+                type_entry = self.query_first(cv.CvTerm, cvterm_id=existing_entry.type_id)
+                self.printer.print("Deleted relationship: '" + subject_name + "', '" + type_entry.name + "', '"
+                                   + object_entry.uniquename + "'")
+
+        return deleted_entries
+
     def _handle_synonym(self, new_entry: sequence.Synonym) -> sequence.Synonym:
         """Inserts or updates an entry in the 'synonym' table, and returns it"""
 
@@ -322,7 +452,7 @@ class ImportClient(IOClient):
             return new_entry
 
     def _handle_feature_synonym(self, new_entry: sequence.FeatureSynonym,
-                                existing_entries: List[sequence.FeatureSynonym], synonym="", feature=""
+                                existing_entries: List[sequence.FeatureSynonym], synonym="", feature_name=""
                                 ) -> sequence.FeatureSynonym:
         """Inserts or updates an entry in the 'feature_synonym' table, and returns it"""
 
@@ -334,14 +464,36 @@ class ImportClient(IOClient):
             # Note that there are potentially multiple entries (for different pub_ids). Ignored here.
             matching_entry = matching_entries[0]
             if self.update_feature_synonym_properties(matching_entry, new_entry):
-                self.printer.print("Updated synonym '" + synonym + "' for feature '" + feature + "'")
+                self.printer.print("Updated synonym '" + synonym + "' for feature '" + feature_name + "'")
             return matching_entry
         else:
 
             # Insert a new feature_synonym entry
             self.add_and_flush(new_entry)
-            self.printer.print("Inserted synonym '" + synonym + "' for feature '" + feature + "'")
+            self.printer.print("Inserted synonym '" + synonym + "' for feature '" + feature_name + "'")
             return new_entry
+
+    def _delete_feature_synonym(self, new_entries: List[sequence.FeatureSynonym],
+                                existing_entries: List[sequence.FeatureSynonym], feature_name=""
+                                ) -> List[sequence.FeatureSynonym]:
+        """Deletes entries from the 'feature_synonym' table"""
+
+        # Loop over all entries in the database
+        deleted_entries = []
+        for existing_entry in existing_entries:
+
+            # Check if the entry is also present in the file
+            matching_entries = utils.filter_objects(new_entries, synonym_id=existing_entry.synonym_id,
+                                                    pub_id=existing_entry.pub_id)
+            if not matching_entries:
+
+                # Delete the entry from the database
+                self.session.delete(existing_entry)
+                deleted_entries.append(existing_entry)
+                synonym_entry = self.query_first(sequence.Synonym, synonym_id=existing_entry.synonym_id)
+                self.printer.print("Deleted synonym '" + synonym_entry.name + "' for feature '" + feature_name + "'")
+
+        return deleted_entries
 
     def _handle_pub(self, new_entry: pub.Pub) -> pub.Pub:
         """Inserts or updates an entry in the 'pub' table, and returns it"""
@@ -362,7 +514,7 @@ class ImportClient(IOClient):
             return new_entry
 
     def _handle_feature_pub(self, new_entry: sequence.FeaturePub, existing_entries: List[sequence.FeaturePub],
-                            feature="", publication="") -> sequence.FeaturePub:
+                            feature_name="", publication="") -> sequence.FeaturePub:
         """Inserts or updates an entry in the 'feature_pub' table, and returns it"""
 
         # Check if the feature_pub is already present in the database
@@ -376,8 +528,38 @@ class ImportClient(IOClient):
 
             # Insert a new feature_pub entry
             self.add_and_flush(new_entry)
-            self.printer.print("Inserted publication '" + publication + "' for feature '" + feature + "'")
+            self.printer.print("Inserted publication '" + publication + "' for feature '" + feature_name + "'")
             return new_entry
+
+    def _delete_feature_pub(self, new_entries: List[sequence.FeaturePub],
+                            existing_entries: List[sequence.FeaturePub], feature_name="") -> List[sequence.FeaturePub]:
+        """Deletes entries from the 'feature_pub' table"""
+
+        # Loop over all entries in the database
+        deleted_entries = []
+        for existing_entry in existing_entries:
+
+            # Check if the entry is also present in the file
+            matching_entries = utils.filter_objects(new_entries, pub_id=existing_entry.pub_id)
+            if not matching_entries:
+
+                # Delete the entry from the database
+                self.session.delete(existing_entry)
+                deleted_entries.append(existing_entry)
+                pub_entry = self.query_first(pub.Pub,  pub_id=existing_entry.pub_id)
+                self.printer.print("Deleted publication '" + pub_entry.uniquename
+                                   + "' for feature '" + feature_name + "'")
+
+        return deleted_entries
+
+    def _mark_feature_as_obsolete(self, organism_entry: organism.Organism, uniquename: str) -> sequence.Feature:
+        """Marks a feature as obsolete"""
+        feature_entry = self.query_first(sequence.Feature, organism_id=organism_entry.organism_id,
+                                         uniquename=uniquename)
+        if not feature_entry.is_obsolete:
+            feature_entry.is_obsolete = True
+            self.printer.print("Marked feature '" + feature_entry.uniquename + "' as obsolete")
+        return feature_entry
 
     @staticmethod
     def update_pub_properties(existing_entry: pub.Pub, new_entry: pub.Pub) -> bool:

--- a/pychado/tasks.py
+++ b/pychado/tasks.py
@@ -174,7 +174,8 @@ def run_import_command(specifier: str, arguments, uri: str) -> None:
         loader.load(file, arguments.format, arguments.database_authority)
     elif specifier == "gff":
         loader = gff.GFFImportClient(uri, arguments.verbose)
-        loader.load(file, arguments.organism, arguments.fasta)
+        loader.load(file, arguments.organism, arguments.fasta, arguments.fresh_load, arguments.force,
+                    arguments.full_genome)
     elif specifier == "fasta":
         loader = fasta.FastaImportClient(uri, arguments.verbose)
         loader.load(file, arguments.organism, arguments.sequence_type)

--- a/pychado/tests/arguments_tests.py
+++ b/pychado/tests/arguments_tests.py
@@ -268,12 +268,24 @@ class TestArguments(unittest.TestCase):
 
     def test_import_gff_args(self):
         # Tests if the command line arguments for the subcommand 'chado import gff' are parsed correctly
-        args = ["chado", "import", "gff", "-f", "testfile", "-a", "testorganism", "--fasta", "testfasta", "testdb"]
+        args = ["chado", "import", "gff", "-f", "testfile", "-a", "testorganism", "--fasta", "testfasta",
+                "--fresh_load", "--force", "--full_genome", "testdb"]
         parsed_args = vars(chado_tools.parse_arguments(args))
         self.assertEqual(parsed_args["input_file"], "testfile")
         self.assertEqual(parsed_args["organism"], "testorganism")
         self.assertEqual(parsed_args["fasta"], "testfasta")
+        self.assertTrue(parsed_args["fresh_load"])
+        self.assertTrue(parsed_args["force"])
+        self.assertTrue(parsed_args["full_genome"])
         self.assertEqual(parsed_args["dbname"], "testdb")
+
+        # Test the default values / alternatives
+        args = ["chado", "import", "gff", "-f", "testfile", "-a", "testorganism", "testdb"]
+        parsed_args = vars(chado_tools.parse_arguments(args))
+        self.assertIsNone(parsed_args["fasta"])
+        self.assertFalse(parsed_args["fresh_load"])
+        self.assertFalse(parsed_args["force"])
+        self.assertFalse(parsed_args["full_genome"])
 
     def test_import_fasta_args(self):
         # Tests if the command line arguments for the subcommand 'chado import fasta' are parsed correctly

--- a/pychado/tests/ddl_tests.py
+++ b/pychado/tests/ddl_tests.py
@@ -1,5 +1,4 @@
 import unittest.mock
-import sqlalchemy.event
 import sqlalchemy.schema
 from .. import dbutils, utils, ddl
 

--- a/pychado/tests/io_gff_tests.py
+++ b/pychado/tests/io_gff_tests.py
@@ -387,6 +387,15 @@ class TestGFF(unittest.TestCase):
         mock_mark.assert_any_call(organism_entry, "id2")
         self.assertEqual(mock_mark.call_count, 2)
 
+    def test_check_attributes(self):
+        # Tests the function that checks if all attributes of a GFF file entry are recognized
+        feature = self.default_gff_entry
+        recognized = self.client._check_if_attributes_are_recognized(feature)
+        self.assertTrue(recognized)
+        feature.attributes["other_attribute"] = "other_value"
+        recognized = self.client._check_if_attributes_are_recognized(feature)
+        self.assertFalse(recognized)
+
     def test_create_feature(self):
         # Tests the function that creates an entry for the 'feature' table
         feature = self.client._create_feature(self.default_gff_entry, 3, 5)
@@ -418,6 +427,15 @@ class TestGFF(unittest.TestCase):
         feature.attributes = {"Name": ["othername"]}
         name = self.client._extract_name(feature)
         self.assertEqual(name, "othername")
+
+    def test_extract_size(self):
+        # Tests the function that extracts the sequence length from a GFF file entry
+        feature = gffutils.Feature()
+        size = self.client._extract_size(feature)
+        self.assertIsNone(size)
+        feature.attributes = {"size": "587"}
+        size = self.client._extract_size(feature)
+        self.assertEqual(size, 587)
 
     def test_extract_synonyms(self):
         # Tests the function that extracts the synonyms from a GFF file entry

--- a/pychado/tests/tasks_tests.py
+++ b/pychado/tests/tasks_tests.py
@@ -413,11 +413,13 @@ class TestTasks(unittest.TestCase):
     def test_import_gff(self, mock_client):
         # Checks that the function importing a GFF file into the database is correctly called
         self.assertIs(mock_client, gff.GFFImportClient)
-        args = ["chado", "import", "gff", "-f", "testfile", "-a", "testorganism", "--fasta", "testfasta", "testdb"]
+        args = ["chado", "import", "gff", "-f", "testfile", "-a", "testorganism", "--fasta", "testfasta",
+                "--fresh_load", "--force", "--full_genome", "testdb"]
         parsed_args = chado_tools.parse_arguments(args)
         tasks.run_import_command(args[2], parsed_args, self.uri)
         mock_client.assert_called_with(self.uri, False)
-        self.assertIn(unittest.mock.call().load("testfile", "testorganism", "testfasta"), mock_client.mock_calls)
+        self.assertIn(unittest.mock.call().load("testfile", "testorganism", "testfasta", True, True, True),
+                      mock_client.mock_calls)
 
     @unittest.mock.patch('pychado.io.fasta.FastaImportClient')
     def test_import_fasta(self, mock_client):


### PR DESCRIPTION
- specify two working modes for GFF import: "update" (default) or "fresh load" (option --fresh_load)
- fresh load: purge all existing entries if option --force is employed
- update: delete attributes not present in input file; insert/update as before
- update: mark features not present in input file as obsolete, if option --full_genome is employed
- recognize some further attributes in GFF, and show warnings if unrecognized attributes are found
- tests for all new functions