### PR TITLE
Gaf

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,21 +13,22 @@ Python3 command line script providing various tools for accessing CHADO database
     * [Required dependencies](#required-dependencies)
     * [From source](#from-source)
     * [Using pip](#using-pip)
-    * [Bioconda](#bioconda)
+    * [Using Bioconda](#using-bioconda)
   * [Usage](#usage)
     * [Available commands](#available-commands)
     * [Examples](#examples)
+    * [Note](#note)
   * [License](#license)
   * [Feedback/Issues](#feedbackissues)
 
 ## Installation
-chado-tools has the following dependencies:
-
-### Required dependencies
-* Python 3.6 or higher
-* PostgreSQL 9.6 or higher
 
 There are a number of ways to install chado-tools and details are provided below. If you encounter an issue when installing chado-tools please contact your local system administrator. If you encounter a bug please log it [here](https://github.com/sanger-pathogens/chado-tools/issues) or email us at path-help@sanger.ac.uk.
+
+### Required dependencies
+
+* Python 3.6 or higher
+* PostgreSQL 9.6 or higher
 
 ### From source
 
@@ -49,12 +50,13 @@ You can install the program from the *Python Package Index (PyPI)* using the com
 
     pip install chado-tools
 
-### Bioconda    
+Now change the default connection parameters by running `chado init`. You can always reset them to the original state by running `chado reset`.
+
+### Using Bioconda
+
 The program is also available as *Bioconda* package. Install it with the command
 
     conda install -c bioconda chado-tools
-
-Now change the default connection parameters by running `chado init`. You can always reset them to the original state by running `chado reset`.
 
 ## Usage
 

--- a/pychado/chado_tools.py
+++ b/pychado/chado_tools.py
@@ -105,7 +105,8 @@ def import_commands() -> dict:
         "essentials": "import basic terms into the CHADO database (for setup)",
         "ontology": "import an ontology into the CHADO database",
         "fasta": "import sequences from a FASTA file into the CHADO database",
-        "gff": "import genomic data from a GFF3 file into the CHADO database"
+        "gff": "import genomic data from a GFF3 file into the CHADO database",
+        "gaf": "import gene annotation data from a GAF file into the CHADO database"
     }
 
 
@@ -369,6 +370,8 @@ def add_import_arguments_by_command(command: str, parser: argparse.ArgumentParse
         add_import_gff_arguments(parser)
     elif command == "fasta":
         add_import_fasta_arguments(parser)
+    elif command == "gaf":
+        add_import_gaf_arguments(parser)
     else:
         print("Command '" + parser.prog + "' is not available.")
 
@@ -405,3 +408,10 @@ def add_import_fasta_arguments(parser: argparse.ArgumentParser):
                         help="abbreviation/short name of the organism")
     parser.add_argument("-t", "--sequence_type", choices={"chromosome", "supercontig", "contig", "region"},
                         default="region", help="type of the sequences (default: region)")
+
+
+def add_import_gaf_arguments(parser: argparse.ArgumentParser):
+    """Defines formal arguments for the 'chado import gaf' sub-command"""
+    parser.add_argument("-f", "--input_file", required=True, help="GFF3 input file")
+    parser.add_argument("-a", "--abbreviation", required=True, dest="organism",
+                        help="abbreviation/short name of the organism")

--- a/pychado/chado_tools.py
+++ b/pychado/chado_tools.py
@@ -393,6 +393,8 @@ def add_import_gff_arguments(parser: argparse.ArgumentParser):
     parser.add_argument("-a", "--abbreviation", required=True, dest="organism",
                         help="abbreviation/short name of the organism")
     parser.add_argument("--fasta", help="FASTA input file with sequences")
+    parser.add_argument("-t", "--sequence_type", choices={"chromosome", "supercontig", "contig", "region"},
+                        default="region", help="type of the FASTA sequences, if present (default: region)")
     parser.add_argument("--fresh_load", action="store_true",
                         help="load a genome from scratch (default: load an update to an existing genome)")
     parser.add_argument("--force", action="store_true",

--- a/pychado/ddl.py
+++ b/pychado/ddl.py
@@ -104,7 +104,7 @@ class RolesClient(DDLClient):
         if specific_schema:
             schemata = [specific_schema]
         else:
-            schemata = ["public", "audit"]
+            schemata = ["public", "audit", "graph"]
 
         # Loop over all schemata
         for schema in schemata:

--- a/pychado/io/essentials.py
+++ b/pychado/io/essentials.py
@@ -14,6 +14,7 @@ class EssentialsClient(iobase.ImportClient):
         self._load_feature_property_entries()
         self._load_genedb_synonymtype_entries()
         self._load_genedb_misc_entries()
+        self._load_genedb_products_vocabulary()
         self.session.commit()
 
     def _load_generic_entries(self):
@@ -92,7 +93,7 @@ class EssentialsClient(iobase.ImportClient):
         new_feature_property_cv = cv.Cv(name="feature_property")
         feature_property_cv = self._handle_cv(new_feature_property_cv)
 
-        for term in ["comment", "score", "source", "description"]:
+        for term in ["comment", "score", "source", "description", "date"]:
 
             new_dbxref = general.DbxRef(db_id=feature_property_db.db_id, accession=term)
             dbxref = self._handle_dbxref(new_dbxref, feature_property_db.name)
@@ -120,12 +121,19 @@ class EssentialsClient(iobase.ImportClient):
         new_misc_cv = cv.Cv(name="genedb_misc")
         misc_cv = self._handle_cv(new_misc_cv)
 
-        for term in ["top_level_seq"]:
+        for term in ["top_level_seq", "evidence"]:
 
             new_dbxref = general.DbxRef(db_id=misc_db.db_id, accession=term)
             dbxref = self._handle_dbxref(new_dbxref, misc_db.name)
             new_cvterm = cv.CvTerm(cv_id=misc_cv.cv_id, dbxref_id=dbxref.dbxref_id, name=term)
             self._handle_cvterm(new_cvterm, misc_cv.name)
+
+    def _load_genedb_products_vocabulary(self):
+        """Import CV for GeneDB products"""
+        new_product_db = general.Db(name="PRODUCT")
+        self._handle_db(new_product_db)
+        new_product_cv = cv.Cv(name="genedb_products")
+        self._handle_cv(new_product_cv)
 
     def _load_sequence_type_entries(self):
         """Import CV terms for sequence types; for testing only (all terms are part of the SO sequence ontology)"""

--- a/pychado/io/gaf.py
+++ b/pychado/io/gaf.py
@@ -1,0 +1,253 @@
+from typing import List, Dict, Union
+from Bio.UniProt import GOA
+from . import iobase, ontology
+from ..orm import general, cv, organism, pub, sequence
+
+
+class GAFImportClient(iobase.ImportClient):
+    """Class for importing genomic data from GAF files into Chado"""
+
+    def __init__(self, uri: str, verbose=False):
+        """Constructor"""
+
+        # Connect to database
+        self.uri = uri
+        self.verbose = verbose
+        super().__init__(self.uri, self.verbose)
+
+        # Load essentials
+        self._date_term = self._load_cvterm("date")
+        self._evidence_term = self._load_cvterm("evidence")
+        self._default_pub = self._load_pub("null")
+
+    def load(self, filename: str, organism_name: str):
+        """Import data from a GAF file into a Chado database"""
+
+        # Load dependencies
+        default_organism = self._load_organism(organism_name)
+        features_with_product = set()
+
+        # Loop over all entries in the GAF file
+        with open(filename) as f:
+            for gaf_record in GOA.gafiterator(f):
+
+                # Get the feature entry
+                feature_entry = self._load_feature(gaf_record, default_organism)
+                if not feature_entry:
+                    continue
+
+                # Update/insert a feature_cvterm entry for the gene product
+                if feature_entry.uniquename not in features_with_product:
+                    self._handle_product_term(gaf_record, feature_entry)
+                    features_with_product.add(feature_entry.uniquename)
+
+                # Update/insert a feature_cvterm entry for the ontology term
+                feature_cvterm_entry = self._handle_ontology_term(gaf_record, feature_entry)
+                if not feature_cvterm_entry:
+                    continue
+
+                # Update/insert feature_cvtermprop entries for date and evidence code
+                self._handle_properties(gaf_record, feature_cvterm_entry)
+
+                # Update/insert feature_cvterm_dbxref entries
+                self._handle_crossrefs(gaf_record, feature_cvterm_entry)
+
+        # Commit changes
+        self.session.commit()
+
+    def _load_feature(self, gaf_record: dict, organism_entry: organism.Organism) -> Union[None, sequence.Feature]:
+        """Loads a feature entry from the database"""
+        feature_name = gaf_record["DB_Object_ID"].strip()
+        if not feature_name:
+            return None
+        feature_entry = self.query_first(sequence.Feature, organism_id=organism_entry.organism_id,
+                                         uniquename=feature_name)
+        return feature_entry
+
+    def _handle_ontology_term(self, gaf_record: dict, feature_entry: sequence.Feature
+                              ) -> Union[None, sequence.FeatureCvTerm]:
+        """Inserts or updates an entry in the 'feature_cvterm' table and returns it"""
+
+        # Extract ontology identifier from the GAF record and split it into db, accession, version
+        ontology_term = gaf_record["GO_ID"].strip()
+        (db_authority, accession, version) = ontology.split_dbxref(ontology_term)
+        publication = gaf_record["DB:Reference"][0].strip()
+
+        # Extract existing ontology terms for this feature from the database
+        existing_feature_cvterms = self.query_feature_cvterm_by_ontology(feature_entry.feature_id, [db_authority]).all()
+
+        # Get entry from 'db' table
+        db_entry = self.query_first(general.Db, name=db_authority)
+        if not db_entry:
+            self.printer.print("WARNING: Ontology '" + db_authority + "' not present in database.")
+            return None
+
+        # Get entry from 'dbxref' table
+        dbxref_entry = self.query_first(general.DbxRef, db_id=db_entry.db_id, accession=accession)
+        if not dbxref_entry:
+            self.printer.print("WARNING: Ontology term '" + ontology_term + "' not present in database.")
+            return None
+
+        # Get entry from 'cvterm' table
+        cvterm_entry = self.query_first(cv.CvTerm, dbxref_id=dbxref_entry.dbxref_id)
+        if not cvterm_entry:
+            self.printer.print("WARNING: CV term for ontology term '" + ontology_term
+                               + "' not present in database.")
+            return None
+
+        # Insert/update entry in the 'pub' table
+        if publication:
+            new_pub_entry = pub.Pub(uniquename=publication, type_id=self._default_pub.type_id)
+            pub_entry = self._handle_pub(new_pub_entry)
+        else:
+            pub_entry = self._default_pub
+
+        # Insert/update entry in the 'feature_cvterm' table
+        new_feature_cvterm_entry = sequence.FeatureCvTerm(feature_id=feature_entry.feature_id,
+                                                          cvterm_id=cvterm_entry.cvterm_id,
+                                                          pub_id=pub_entry.pub_id,
+                                                          is_not=("NOT" in gaf_record["Qualifier"]))
+        feature_cvterm_entry = self._handle_feature_cvterm(new_feature_cvterm_entry, existing_feature_cvterms,
+                                                           cvterm_entry.name, feature_entry.uniquename)
+        return feature_cvterm_entry
+
+    def _handle_product_term(self, gaf_record: dict, feature_entry: sequence.Feature
+                             ) -> Union[None, sequence.FeatureCvTerm]:
+        """Inserts or updates an entry in the 'feature_cvterm' table and returns it"""
+
+        # Extract the product name from the GAF record
+        product = gaf_record["DB_Object_Name"].strip()
+        if not product:
+            return None
+        publication = gaf_record["DB:Reference"][0].strip()
+
+        # Extract existing product terms for this feature from the database
+        existing_feature_cvterms = self.query_feature_cvterm_by_ontology(feature_entry.feature_id, ["PRODUCT"]).all()
+
+        # Insert/update entry in the 'db' table
+        new_db_entry = general.Db(name="PRODUCT")
+        db_entry = self._handle_db(new_db_entry)
+
+        # Insert/update entry in the 'dbxref' table
+        new_dbxref_entry = general.DbxRef(db_id=db_entry.db_id, accession=product)
+        dbxref_entry = self._handle_dbxref(new_dbxref_entry, db_entry.name)
+
+        # Insert/update entry in the 'cv' table
+        new_cv_entry = cv.Cv(name="genedb_products")
+        cv_entry = self._handle_cv(new_cv_entry)
+
+        # Insert/update entry in the 'cvterm' table
+        new_cvterm_entry = cv.CvTerm(cv_id=cv_entry.cv_id, dbxref_id=dbxref_entry.dbxref_id, name=product)
+        cvterm_entry = self._handle_cvterm(new_cvterm_entry, cv_entry.name)
+
+        # Insert/update entry in the 'pub' table
+        if publication:
+            new_pub_entry = pub.Pub(uniquename=publication, type_id=self._default_pub.type_id)
+            pub_entry = self._handle_pub(new_pub_entry)
+        else:
+            pub_entry = self._default_pub
+
+        # Insert/update entry in the 'feature_cvterm' table
+        new_feature_cvterm_entry = sequence.FeatureCvTerm(feature_id=feature_entry.feature_id,
+                                                          cvterm_id=cvterm_entry.cvterm_id,
+                                                          pub_id=pub_entry.pub_id)
+        feature_cvterm_entry = self._handle_feature_cvterm(new_feature_cvterm_entry, existing_feature_cvterms,
+                                                           cvterm_entry.name, feature_entry.uniquename)
+        return feature_cvterm_entry
+
+    def _handle_properties(self, gaf_record: dict, feature_cvterm_entry: sequence.FeatureCvTerm
+                           ) -> List[sequence.FeatureCvTermProp]:
+        """Inserts or updates entries in the 'feature_cvtermprop' table and returns them"""
+
+        # Extract existing properties for this feature_cvterm from the database
+        existing_feature_cvtermprops = self.query_all(sequence.FeatureCvTermProp,
+                                                      feature_cvterm_id=feature_cvterm_entry.feature_cvterm_id)
+
+        # Insert/update entry for 'date'
+        date = gaf_record["Date"].strip()
+        new_feature_cvtermprop_entry = sequence.FeatureCvTermProp(
+            feature_cvterm_id=feature_cvterm_entry.feature_cvterm_id, type_id=self._date_term.cvterm_id, value=date)
+        date_feature_cvtermprop_entry = self._handle_feature_cvtermprop(
+            new_feature_cvtermprop_entry, existing_feature_cvtermprops, "date")
+
+        # Insert/update entry for 'evidence'
+        evidence_code = self._convert_evidence_code(gaf_record["Evidence"])
+        new_feature_cvtermprop_entry = sequence.FeatureCvTermProp(
+            feature_cvterm_id=feature_cvterm_entry.feature_cvterm_id, type_id=self._evidence_term.cvterm_id,
+            value=evidence_code)
+        evidence_feature_cvtermprop_entry = self._handle_feature_cvtermprop(
+            new_feature_cvtermprop_entry, existing_feature_cvtermprops, "evidence")
+
+        return [date_feature_cvtermprop_entry, evidence_feature_cvtermprop_entry]
+
+    def _handle_crossrefs(self, gaf_record: dict, feature_cvterm_entry: sequence.FeatureCvTerm
+                          ) -> List[sequence.FeatureCvTermDbxRef]:
+        """Inserts or updates an entry in the 'feature_cvterm_dbxref' table and returns it"""
+
+        # Extract existing cross references for this feature_cvterm from the database
+        existing_feature_cvterm_dbxrefs = self.query_all(sequence.FeatureCvTermDbxRef,
+                                                         feature_cvterm_id=feature_cvterm_entry.feature_cvterm_id)
+        all_feature_cvterm_dbxrefs = []
+
+        # Loop over all cross references of the given GAF record
+        for crossref in gaf_record["With"]:
+
+            # Split database cross reference (dbxref) into db, accession, version
+            if not crossref.strip():
+                continue
+            (db_authority, accession, version) = ontology.split_dbxref(crossref)
+
+            # Insert/update entry in the 'db' table
+            new_db_entry = general.Db(name=db_authority)
+            db_entry = self._handle_db(new_db_entry)
+
+            # Insert/update entry in the 'dbxref' table
+            new_dbxref_entry = general.DbxRef(db_id=db_entry.db_id, accession=accession, version=version)
+            dbxref_entry = self._handle_dbxref(new_dbxref_entry, db_authority)
+
+            # Insert/update entry in the 'feature_cvterm_dbxref' table
+            new_feature_cvterm_dbxref_entry = sequence.FeatureCvTermDbxRef(
+                feature_cvterm_id=feature_cvterm_entry.feature_cvterm_id, dbxref_id=dbxref_entry.dbxref_id)
+            feature_cvterm_dbxref_entry = self._handle_feature_cvterm_dbxref(
+                new_feature_cvterm_dbxref_entry, existing_feature_cvterm_dbxrefs, crossref)
+            all_feature_cvterm_dbxrefs.append(feature_cvterm_dbxref_entry)
+
+        return all_feature_cvterm_dbxrefs
+
+    def _convert_evidence_code(self, abbreviation: str) -> str:
+        """Converts the abbreviation for an evidence code into the spelled-out version, if applicable"""
+        if abbreviation in self._evidence_codes():
+            return self._evidence_codes()[abbreviation]
+        return abbreviation
+
+    @staticmethod
+    def _evidence_codes() -> Dict[str, str]:
+        """Lists the GO evidence codes and their respective abbreviations"""
+        return {
+            "EXP": "Inferred from Experiment",
+            "IDA": "Inferred from Direct Assay",
+            "IPI": "Inferred from Physical Interaction",
+            "IMP": "Inferred from Mutant Phenotype",
+            "IGI": "Inferred from Genetic Interaction",
+            "IEP": "Inferred from Expression Pattern",
+            "HTP": "Inferred from High Throughput Experiment",
+            "HDA": "Inferred from High Throughput Direct Assay",
+            "HMP": "Inferred from High Throughput Mutant Phenotype",
+            "HGI": "Inferred from High Throughput Genetic Interaction",
+            "HEP": "Inferred from High Throughput Expression Pattern",
+            "ISS": "Inferred from Sequence or structural Similarity",
+            "ISO": "Inferred from Sequence Orthology",
+            "ISA": "Inferred from Sequence Alignment",
+            "ISM": "Inferred from Sequence Model",
+            "IGC": "Inferred from Genomic Context",
+            "IBA": "Inferred from Biological aspect of Ancestor",
+            "IBD": "Inferred from Biological aspect of Descendant",
+            "IKR": "Inferred from Key Residues",
+            "IRD": "Inferred from Rapid Divergence",
+            "RCA": "Inferred from Reviewed Computational Analysis",
+            "TAS": "Traceable Author Statement",
+            "NAS": "Non-traceable Author Statement",
+            "IC": "Inferred by Curator",
+            "ND": "No biological Data available",
+            "IEA": "Inferred from Electronic Annotation"
+        }

--- a/pychado/io/gff.py
+++ b/pychado/io/gff.py
@@ -185,13 +185,13 @@ class GFFImportClient(iobase.ImportClient):
         """Marks features as obsolete"""
 
         # Loop over all features for the given organism in the database
-        for feature_id in self._load_feature_ids(organism_entry):
+        for feature_name in self._load_feature_names(organism_entry):
 
             # Check if the feature is also present in the input file
-            if feature_id not in all_features and feature_id not in top_level_features:
+            if feature_name not in all_features and feature_name not in top_level_features:
 
                 # Mark the feature as obsolete, if necessary
-                self._mark_feature_as_obsolete(organism_entry, feature_id)
+                self._mark_feature_as_obsolete(organism_entry, feature_name)
 
     def _handle_child_feature(self, gff_feature: gffutils.Feature, organism_entry: organism.Organism
                               ) -> Union[None, sequence.Feature]:

--- a/pychado/io/gff.py
+++ b/pychado/io/gff.py
@@ -40,8 +40,8 @@ class GFFImportClient(iobase.ImportClient):
             if os.path.exists(database):
                 os.remove(database)
 
-    def load(self, filename: str, organism_name: str, fasta_filename: str, fresh_load=False, force_purge=False,
-             full_genome=False):
+    def load(self, filename: str, organism_name: str, fasta_filename: str, sequence_type: str, fresh_load=False,
+             force_purge=False, full_genome=False):
         """Import data from a GFF3 file into a Chado database"""
 
         # Check for file existence
@@ -53,7 +53,7 @@ class GFFImportClient(iobase.ImportClient):
         self._handle_existing_features(default_organism, fresh_load, force_purge)
 
         # Import FASTA sequences, if present
-        self._import_fasta(filename, fasta_filename, organism_name)
+        self._import_fasta(filename, fasta_filename, organism_name, sequence_type)
 
         # Create temporary SQLite database
         gff_db = self._create_sqlite_db(filename)
@@ -92,7 +92,7 @@ class GFFImportClient(iobase.ImportClient):
         # Commit changes
         self.session.commit()
 
-    def _import_fasta(self, gff_file: str, fasta_file: str, organism_name: str) -> None:
+    def _import_fasta(self, gff_file: str, fasta_file: str, organism_name: str, sequence_type: str) -> None:
         """Imports sequences from a FASTA file into the Chado database"""
 
         # Check if the GFF file contains FASTA sequences
@@ -114,7 +114,7 @@ class GFFImportClient(iobase.ImportClient):
         # Import sequences from FASTA file, if present
         if fasta_file:
             fasta_client = fasta.FastaImportClient(self.uri, self.verbose)
-            fasta_client.load(fasta_file, organism_name, "region")
+            fasta_client.load(fasta_file, organism_name, sequence_type)
 
         # Delete temporary file
         if fasta_is_temporary and os.path.exists(fasta_file):

--- a/pychado/io/iobase.py
+++ b/pychado/io/iobase.py
@@ -580,9 +580,9 @@ class ImportClient(IOClient):
     def _handle_feature_cvterm_dbxref(self, new_entry: sequence.FeatureCvTermDbxRef,
                                       existing_entries: List[sequence.FeatureCvTermDbxRef], crossref=""
                                       ) -> sequence.FeatureCvTermDbxRef:
-        """Inserts or updates an entry in the 'feature_pub' table, and returns it"""
+        """Inserts or updates an entry in the 'feature_cvterm_dbxref' table, and returns it"""
 
-        # Check if the feature_pub is already present in the database
+        # Check if the feature_cvterm_dbxref is already present in the database
         matching_entries = utils.filter_objects(existing_entries, dbxref_id=new_entry.dbxref_id)
         if matching_entries:
 
@@ -594,6 +594,25 @@ class ImportClient(IOClient):
             # Insert a new feature_cvterm_dbxref entry
             self.add_and_flush(new_entry)
             self.printer.print("Inserted cross reference '" + crossref + "'")
+            return new_entry
+
+    def _handle_feature_cvterm_pub(self, new_entry: sequence.FeatureCvTermPub,
+                                   existing_entries: List[sequence.FeatureCvTermPub], publication=""
+                                   ) -> sequence.FeatureCvTermPub:
+        """Inserts or updates an entry in the 'feature_cvterm_pub' table, and returns it"""
+
+        # Check if the feature_cvterm_pub is already present in the database
+        matching_entries = utils.filter_objects(existing_entries, pub_id=new_entry.pub_id)
+        if matching_entries:
+
+            # Nothing to update, return existing entry
+            matching_entry = matching_entries[0]
+            return matching_entry
+        else:
+
+            # Insert a new feature_cvterm_pub entry
+            self.add_and_flush(new_entry)
+            self.printer.print("Inserted publication '" + publication + "'")
             return new_entry
 
     def _mark_feature_as_obsolete(self, organism_entry: organism.Organism, uniquename: str) -> sequence.Feature:

--- a/pychado/orm/sequence.py
+++ b/pychado/orm/sequence.py
@@ -84,7 +84,7 @@ class FeatureCvTerm(base.PublicBase):
     pub = sqlalchemy.orm.relationship(pub.Pub, foreign_keys=pub_id, backref="feature_cvterm_pub")
 
     # Initialisation
-    def __init__(self, feature_id, cvterm_id, pub_id, is_not=False, rank=0, feature_cvterm_id=None):
+    def __init__(self, feature_id, cvterm_id, pub_id, is_not=None, rank=0, feature_cvterm_id=None):
         for key, value in locals().items():
             if key != self:
                 setattr(self, key, value)
@@ -162,6 +162,38 @@ class FeatureCvTermProp(base.PublicBase):
         return "<sequence.FeatureCvTermProp(feature_cvtermprop_id={0}, feature_cvterm_id={1}, type_id={2}, " \
                "value='{3}', rank={4})>".format(self.feature_cvtermprop_id, self.feature_cvterm_id, self.type_id,
                                                 self.value, self.rank)
+
+
+class FeatureCvTermPub(base.PublicBase):
+    """Class for the CHADO 'feature_cvterm_pub' table"""
+    # Columns
+    feature_cvterm_pub_id = sqlalchemy.Column(sqlalchemy.BIGINT, nullable=False, primary_key=True, autoincrement=True)
+    feature_cvterm_id = sqlalchemy.Column(sqlalchemy.BIGINT, sqlalchemy.ForeignKey(
+        FeatureCvTerm.feature_cvterm_id, onupdate="CASCADE", ondelete="CASCADE"), nullable=False)
+    pub_id = sqlalchemy.Column(sqlalchemy.BIGINT, sqlalchemy.ForeignKey(
+        pub.Pub.pub_id, onupdate="CASCADE", ondelete="CASCADE"), nullable=False)
+
+    # Constraints
+    __tablename__ = "feature_cvterm_pub"
+    __table_args__ = (sqlalchemy.UniqueConstraint(feature_cvterm_id, pub_id, name="feature_cvterm_pub_c1"),
+                      sqlalchemy.Index("feature_cvterm_pub_idx1", feature_cvterm_id),
+                      sqlalchemy.Index("feature_cvterm_pub_idx2", pub_id))
+
+    # Relationships
+    feature_cvterm = sqlalchemy.orm.relationship(FeatureCvTerm, foreign_keys=feature_cvterm_id,
+                                                 backref="feature_cvterm_pub_feature_cvterm")
+    pub = sqlalchemy.orm.relationship(pub.Pub, foreign_keys=pub_id, backref="feature_cvterm_pub_pub")
+
+    # Initialisation
+    def __init__(self, feature_cvterm_id, pub_id, feature_cvterm_pub_id=None):
+        for key, value in locals().items():
+            if key != self:
+                setattr(self, key, value)
+
+    # Representation
+    def __repr__(self):
+        return "<sequence.FeatureCvTermPub(feature_cvterm_pub_id={0}, feature_cvterm_id={1}, pub_id={2})>".\
+            format(self.feature_cvterm_pub_id, self.feature_cvterm_id, self.pub_id)
 
 
 class FeatureDbxRef(base.PublicBase):

--- a/pychado/tasks.py
+++ b/pychado/tasks.py
@@ -1,5 +1,5 @@
 from . import utils, dbutils, queries, ddl
-from .io import direct, essentials, ontology, fasta, gff
+from .io import direct, essentials, ontology, fasta, gff, gaf
 
 
 def create_connection_string(filename: str, dbname: str) -> str:
@@ -179,5 +179,8 @@ def run_import_command(specifier: str, arguments, uri: str) -> None:
     elif specifier == "fasta":
         loader = fasta.FastaImportClient(uri, arguments.verbose)
         loader.load(file, arguments.organism, arguments.sequence_type)
+    elif specifier == "gaf":
+        loader = gaf.GAFImportClient(uri, arguments.verbose)
+        loader.load(file, arguments.organism)
     else:
         print("Functionality 'import " + specifier + "' is not yet implemented.")

--- a/pychado/tasks.py
+++ b/pychado/tasks.py
@@ -174,8 +174,8 @@ def run_import_command(specifier: str, arguments, uri: str) -> None:
         loader.load(file, arguments.format, arguments.database_authority)
     elif specifier == "gff":
         loader = gff.GFFImportClient(uri, arguments.verbose)
-        loader.load(file, arguments.organism, arguments.fasta, arguments.fresh_load, arguments.force,
-                    arguments.full_genome)
+        loader.load(file, arguments.organism, arguments.fasta, arguments.sequence_type, arguments.fresh_load,
+                    arguments.force, arguments.full_genome)
     elif specifier == "fasta":
         loader = fasta.FastaImportClient(uri, arguments.verbose)
         loader.load(file, arguments.organism, arguments.sequence_type)

--- a/pychado/tests/arguments_tests.py
+++ b/pychado/tests/arguments_tests.py
@@ -57,11 +57,12 @@ class TestCommands(unittest.TestCase):
 
     def test_import_commands(self):
         commands = chado_tools.import_commands()
-        self.assertEqual(len(commands), 4)
+        self.assertEqual(len(commands), 5)
         self.assertIn("essentials", commands)
         self.assertIn("ontology", commands)
         self.assertIn("gff", commands)
         self.assertIn("fasta", commands)
+        self.assertIn("gaf", commands)
 
 
 class TestArguments(unittest.TestCase):
@@ -294,6 +295,14 @@ class TestArguments(unittest.TestCase):
         self.assertEqual(parsed_args["input_file"], "testfile")
         self.assertEqual(parsed_args["organism"], "testorganism")
         self.assertEqual(parsed_args["sequence_type"], "contig")
+        self.assertEqual(parsed_args["dbname"], "testdb")
+
+    def test_import_gaf_args(self):
+        # Tests if the command line arguments for the subcommand 'chado import gaf' are parsed correctly
+        args = ["chado", "import", "gaf", "-f", "testfile", "-a", "testorganism", "testdb"]
+        parsed_args = vars(chado_tools.parse_arguments(args))
+        self.assertEqual(parsed_args["input_file"], "testfile")
+        self.assertEqual(parsed_args["organism"], "testorganism")
         self.assertEqual(parsed_args["dbname"], "testdb")
 
 

--- a/pychado/tests/arguments_tests.py
+++ b/pychado/tests/arguments_tests.py
@@ -270,11 +270,12 @@ class TestArguments(unittest.TestCase):
     def test_import_gff_args(self):
         # Tests if the command line arguments for the subcommand 'chado import gff' are parsed correctly
         args = ["chado", "import", "gff", "-f", "testfile", "-a", "testorganism", "--fasta", "testfasta",
-                "--fresh_load", "--force", "--full_genome", "testdb"]
+                "-t", "contig", "--fresh_load", "--force", "--full_genome", "testdb"]
         parsed_args = vars(chado_tools.parse_arguments(args))
         self.assertEqual(parsed_args["input_file"], "testfile")
         self.assertEqual(parsed_args["organism"], "testorganism")
         self.assertEqual(parsed_args["fasta"], "testfasta")
+        self.assertEqual(parsed_args["sequence_type"], "contig")
         self.assertTrue(parsed_args["fresh_load"])
         self.assertTrue(parsed_args["force"])
         self.assertTrue(parsed_args["full_genome"])

--- a/pychado/tests/io_base_tests.py
+++ b/pychado/tests/io_base_tests.py
@@ -585,6 +585,28 @@ class TestImportClient(unittest.TestCase):
         self.assertIs(second_entry, new_entry)
         self.assertIsNot(second_entry, another_entry)
 
+    def test_handle_feature_cvterm_pub(self):
+        # Tests the function importing a feature_cvterm_pub to the database
+        pub_entry = pub.Pub(uniquename="otherpub", type_id=self.default_cvterm.cvterm_id)
+        self.client.add_and_flush(pub_entry)
+        feature_cvterm_entry = sequence.FeatureCvTerm(feature_id=self.default_feature.feature_id,
+                                                      cvterm_id=self.default_cvterm.cvterm_id,
+                                                      pub_id=self.default_pub.pub_id)
+        self.client.add_and_flush(feature_cvterm_entry)
+
+        new_entry = sequence.FeatureCvTermPub(feature_cvterm_id=feature_cvterm_entry.feature_cvterm_id,
+                                              pub_id=pub_entry.pub_id)
+        first_entry = self.client._handle_feature_cvterm_pub(new_entry, [])
+        self.assertIs(first_entry, new_entry)
+
+        another_entry = sequence.FeatureCvTermPub(feature_cvterm_id=feature_cvterm_entry.feature_cvterm_id,
+                                                  pub_id=pub_entry.pub_id)
+        existing_entries = self.client.query_all(sequence.FeatureCvTermPub,
+                                                 feature_cvterm_id=new_entry.feature_cvterm_id)
+        second_entry = self.client._handle_feature_cvterm_pub(another_entry, existing_entries)
+        self.assertIs(second_entry, new_entry)
+        self.assertIsNot(second_entry, another_entry)
+
     def test_mark_feature_as_obsolete(self):
         # Tests the function that marks a feature as obsolete
         feature = sequence.Feature(organism_id=self.default_organism.organism_id, type_id=self.default_cvterm.cvterm_id,

--- a/pychado/tests/io_gaf_tests.py
+++ b/pychado/tests/io_gaf_tests.py
@@ -1,0 +1,203 @@
+import unittest.mock
+from .. import dbutils, utils
+from ..io import essentials, gaf
+from ..orm import base, general, cv, pub, organism, sequence
+
+
+class TestGAF(unittest.TestCase):
+    """Tests various functions used to load a GFF file into a database"""
+
+    connection_parameters = utils.parse_yaml(dbutils.default_configuration_file())
+    connection_uri = dbutils.random_database_uri(connection_parameters)
+
+    @classmethod
+    def setUpClass(cls):
+        # Creates a database, establishes a connection, creates tables and populates them with essential entries
+        dbutils.create_database(cls.connection_uri)
+        schema_base = base.PublicBase
+        schema_metadata = schema_base.metadata
+        essentials_client = essentials.EssentialsClient(cls.connection_uri)
+        schema_metadata.create_all(essentials_client.engine, tables=schema_metadata.sorted_tables)
+        essentials_client.load()
+        cls.client = gaf.GAFImportClient(cls.connection_uri)
+
+    @classmethod
+    def tearDownClass(cls):
+        # Drops the database
+        dbutils.drop_database(cls.connection_uri, True)
+
+    def setUp(self):
+        # Creates a default GAF record
+        self.default_gaf_record = {'DB': 'testdb', 'DB_Object_ID': 'testname', 'DB_Object_Symbol': 'testsymbol',
+                                   'Qualifier': [''], 'GO_ID': 'GO:12345', 'DB:Reference': ['testdb:testaccession'],
+                                   'Evidence': 'XYZ', 'With': ['evidencedb:evidenceaccession'], 'Aspect': 'C',
+                                   'DB_Object_Name': 'testproduct', 'Synonym': [''], 'DB_Object_Type': 'transcript',
+                                   'Taxon_ID': ['testtaxon'], 'Date': 'testdate', 'Assigned_By': 'testdb'}
+
+
+    @unittest.mock.patch("pychado.io.gaf.GAFImportClient.query_first")
+    def test_load_feature(self, mock_query: unittest.mock.Mock):
+        # Tests the function loading the entry from the 'feature' table that corresponds to a GAF record
+        self.assertIs(mock_query, self.client.query_first)
+        organism_entry = organism.Organism(genus="", species="", abbreviation="testorganism", organism_id=1)
+        self.client._load_feature(self.default_gaf_record, organism_entry)
+        mock_query.assert_called_with(sequence.Feature, organism_id=1, uniquename="testname")
+
+    @unittest.mock.patch("pychado.io.gaf.GAFImportClient._handle_feature_cvterm")
+    @unittest.mock.patch("pychado.orm.sequence.FeatureCvTerm")
+    @unittest.mock.patch("pychado.io.gaf.GAFImportClient._handle_pub")
+    @unittest.mock.patch("pychado.orm.pub.Pub")
+    @unittest.mock.patch("pychado.io.gaf.GAFImportClient.query_first")
+    @unittest.mock.patch("pychado.io.gaf.GAFImportClient.query_feature_cvterm_by_ontology")
+    def test_handle_ontology_term(self, mock_query: unittest.mock.Mock, mock_query_first: unittest.mock.Mock,
+                                  mock_pub: unittest.mock.Mock, mock_insert_pub: unittest.mock.Mock,
+                                  mock_feature_cvterm: unittest.mock.Mock,
+                                  mock_insert_feature_cvterm: unittest.mock.Mock):
+        # Tests the function transferring data from a GAF record to the 'feature_cvterm' table
+        self.assertIs(mock_query, self.client.query_feature_cvterm_by_ontology)
+        self.assertIs(mock_query_first, self.client.query_first)
+        self.assertIs(mock_pub, pub.Pub)
+        self.assertIs(mock_insert_pub, self.client._handle_pub)
+        self.assertIs(mock_feature_cvterm, sequence.FeatureCvTerm)
+        self.assertIs(mock_insert_feature_cvterm, self.client._handle_feature_cvterm)
+
+        feature_entry = sequence.Feature(organism_id=11, type_id=200, uniquename="testname", feature_id=12)
+        mock_query_first.side_effect = [utils.EmptyObject(db_id=33),
+                                        utils.EmptyObject(dbxref_id=44),
+                                        utils.EmptyObject(cvterm_id=55, name="")]
+        mock_insert_pub.return_value = utils.EmptyObject(pub_id=66)
+
+        ontology_term = self.client._handle_ontology_term(self.default_gaf_record, feature_entry)
+        mock_query.assert_called_with(12, ["GO"])
+        mock_query_first.assert_any_call(general.Db, name="GO")
+        mock_query_first.assert_any_call(general.DbxRef, db_id=33, accession="12345")
+        mock_query_first.assert_any_call(cv.CvTerm, dbxref_id=44)
+        self.assertEqual(mock_query_first.call_count, 3)
+        mock_pub.assert_any_call(uniquename="testdb:testaccession", type_id=self.client._default_pub.type_id)
+        self.assertEqual(mock_insert_pub.call_count, 1)
+        mock_feature_cvterm.assert_any_call(feature_id=12, cvterm_id=55, pub_id=66, is_not=False)
+        self.assertEqual(mock_insert_feature_cvterm.call_count, 1)
+        self.assertIsNotNone(ontology_term)
+
+    @unittest.mock.patch("pychado.io.gaf.GAFImportClient._handle_feature_cvterm")
+    @unittest.mock.patch("pychado.orm.sequence.FeatureCvTerm")
+    @unittest.mock.patch("pychado.io.gaf.GAFImportClient._handle_pub")
+    @unittest.mock.patch("pychado.orm.pub.Pub")
+    @unittest.mock.patch("pychado.io.gaf.GAFImportClient._handle_cvterm")
+    @unittest.mock.patch("pychado.orm.cv.CvTerm")
+    @unittest.mock.patch("pychado.io.gaf.GAFImportClient._handle_cv")
+    @unittest.mock.patch("pychado.orm.cv.Cv")
+    @unittest.mock.patch("pychado.io.gaf.GAFImportClient._handle_dbxref")
+    @unittest.mock.patch("pychado.orm.general.DbxRef")
+    @unittest.mock.patch("pychado.io.gaf.GAFImportClient._handle_db")
+    @unittest.mock.patch("pychado.orm.general.Db")
+    @unittest.mock.patch("pychado.io.gaf.GAFImportClient.query_feature_cvterm_by_ontology")
+    def test_handle_product_term(self, mock_query: unittest.mock.Mock,
+                                 mock_db: unittest.mock.Mock, mock_insert_db: unittest.mock.Mock,
+                                 mock_dbxref: unittest.mock.Mock, mock_insert_dbxref: unittest.mock.Mock,
+                                 mock_cv: unittest.mock.Mock, mock_insert_cv: unittest.mock.Mock,
+                                 mock_cvterm: unittest.mock.Mock, mock_insert_cvterm: unittest.mock.Mock,
+                                 mock_pub: unittest.mock.Mock, mock_insert_pub: unittest.mock.Mock,
+                                 mock_feature_cvterm: unittest.mock.Mock,
+                                 mock_insert_feature_cvterm: unittest.mock.Mock):
+        # Tests the function transferring data from a GAF record to the 'feature_cvterm' table
+        self.assertIs(mock_query, self.client.query_feature_cvterm_by_ontology)
+        self.assertIs(mock_db, general.Db)
+        self.assertIs(mock_insert_db, self.client._handle_db)
+        self.assertIs(mock_dbxref, general.DbxRef)
+        self.assertIs(mock_insert_dbxref, self.client._handle_dbxref)
+        self.assertIs(mock_cv, cv.Cv)
+        self.assertIs(mock_insert_cv, self.client._handle_cv)
+        self.assertIs(mock_cvterm, cv.CvTerm)
+        self.assertIs(mock_insert_cvterm, self.client._handle_cvterm)
+        self.assertIs(mock_pub, pub.Pub)
+        self.assertIs(mock_insert_pub, self.client._handle_pub)
+        self.assertIs(mock_feature_cvterm, sequence.FeatureCvTerm)
+        self.assertIs(mock_insert_feature_cvterm, self.client._handle_feature_cvterm)
+
+        feature_entry = sequence.Feature(organism_id=11, type_id=200, uniquename="testname", feature_id=12)
+        mock_insert_db.return_value = utils.EmptyObject(db_id=22, name="")
+        mock_insert_dbxref.return_value = utils.EmptyObject(dbxref_id=33)
+        mock_insert_cv.return_value = utils.EmptyObject(cv_id=44, name="")
+        mock_insert_cvterm.return_value = utils.EmptyObject(cvterm_id=55, name="")
+        mock_insert_pub.return_value = utils.EmptyObject(pub_id=66)
+
+        product_term = self.client._handle_product_term(self.default_gaf_record, feature_entry)
+        mock_query.assert_called_with(12, ["PRODUCT"])
+        mock_db.assert_called_with(name="PRODUCT")
+        mock_dbxref.assert_called_with(db_id=22, accession="testproduct")
+        mock_cv.assert_called_with(name="genedb_products")
+        mock_cvterm.assert_called_with(cv_id=44, dbxref_id=33, name="testproduct")
+        mock_pub.assert_called_with(uniquename="testdb:testaccession", type_id=self.client._default_pub.type_id)
+        mock_feature_cvterm.assert_called_with(feature_id=12, cvterm_id=55, pub_id=66)
+
+        mock_insert_db.assert_called()
+        mock_insert_dbxref.assert_called()
+        mock_insert_cv.assert_called()
+        mock_insert_cvterm.assert_called()
+        mock_insert_pub.assert_called()
+        mock_insert_feature_cvterm.assert_called()
+        self.assertIsNotNone(product_term)
+
+    @unittest.mock.patch("pychado.io.gaf.GAFImportClient._handle_feature_cvtermprop")
+    @unittest.mock.patch("pychado.orm.sequence.FeatureCvTermProp")
+    @unittest.mock.patch("pychado.io.gaf.GAFImportClient.query_all")
+    def test_handle_properties(self, mock_query: unittest.mock.Mock, mock_prop: unittest.mock.Mock,
+                               mock_insert_prop: unittest.mock.Mock):
+        # Tests the function transferring data from a GAF record to the 'feature_cvtermprop' table
+        self.assertIs(mock_query, self.client.query_all)
+        self.assertIs(mock_prop, sequence.FeatureCvTermProp)
+        self.assertIs(mock_insert_prop, self.client._handle_feature_cvtermprop)
+        feature_cvterm_entry = sequence.FeatureCvTerm(feature_id=1, cvterm_id=2, pub_id=3, feature_cvterm_id=4)
+
+        all_properties = self.client._handle_properties(self.default_gaf_record, feature_cvterm_entry)
+        mock_query.assert_called_with(sequence.FeatureCvTermProp, feature_cvterm_id=4)
+        mock_prop.assert_any_call(feature_cvterm_id=4, type_id=self.client._date_term.cvterm_id, value="testdate")
+        mock_prop.assert_any_call(feature_cvterm_id=4, type_id=self.client._evidence_term.cvterm_id, value="XYZ")
+        self.assertEqual(mock_insert_prop.call_count, 2)
+        self.assertEqual(len(all_properties), 2)
+
+    @unittest.mock.patch("pychado.io.gaf.GAFImportClient._handle_feature_cvterm_dbxref")
+    @unittest.mock.patch("pychado.orm.sequence.FeatureCvTermDbxRef")
+    @unittest.mock.patch("pychado.io.gaf.GAFImportClient._handle_dbxref")
+    @unittest.mock.patch("pychado.orm.general.DbxRef")
+    @unittest.mock.patch("pychado.io.gaf.GAFImportClient._handle_db")
+    @unittest.mock.patch("pychado.orm.general.Db")
+    @unittest.mock.patch("pychado.io.gaf.GAFImportClient.query_all")
+    def test_handle_crossrefs(self, mock_query: unittest.mock.Mock, mock_db: unittest.mock.Mock,
+                              mock_insert_db: unittest.mock.Mock, mock_dbxref: unittest.mock.Mock,
+                              mock_insert_dbxref: unittest.mock.Mock, mock_feature_cvterm_dbxref: unittest.mock.Mock,
+                              mock_insert_feature_cvterm_dbxref: unittest.mock.Mock):
+        # Tests the function transferring data from a GAF record to the 'feature_cvterm_dbxref' table
+        self.assertIs(mock_query, self.client.query_all)
+        self.assertIs(mock_db, general.Db)
+        self.assertIs(mock_insert_db, self.client._handle_db)
+        self.assertIs(mock_dbxref, general.DbxRef)
+        self.assertIs(mock_insert_dbxref, self.client._handle_dbxref)
+        self.assertIs(mock_feature_cvterm_dbxref, sequence.FeatureCvTermDbxRef)
+        self.assertIs(mock_insert_feature_cvterm_dbxref, self.client._handle_feature_cvterm_dbxref)
+
+        feature_cvterm_entry = sequence.FeatureCvTerm(feature_id=1, cvterm_id=2, pub_id=3, feature_cvterm_id=4)
+        mock_insert_db.return_value = utils.EmptyObject(db_id=44, name="")
+        mock_insert_dbxref.return_value = utils.EmptyObject(dbxref_id=55, accession="", version="")
+
+        all_crossrefs = self.client._handle_crossrefs(self.default_gaf_record, feature_cvterm_entry)
+        mock_query.assert_called_with(sequence.FeatureCvTermDbxRef, feature_cvterm_id=4)
+        mock_db.assert_any_call(name="evidencedb")
+        mock_dbxref.assert_any_call(db_id=44, accession="evidenceaccession", version="")
+        mock_feature_cvterm_dbxref.assert_any_call(feature_cvterm_id=4, dbxref_id=55)
+        self.assertEqual(mock_insert_db.call_count, 1)
+        self.assertEqual(mock_insert_dbxref.call_count, 1)
+        self.assertEqual(mock_insert_feature_cvterm_dbxref.call_count, 1)
+        self.assertEqual(len(all_crossrefs), 1)
+
+    def test_convert_evidence_code(self):
+        # Tests the function converting an evidence code abbreviation into the spelled-out form
+        code = self.client._convert_evidence_code("HTP")
+        self.assertEqual(code, "Inferred from High Throughput Experiment")
+        code = self.client._convert_evidence_code("XYZ")
+        self.assertEqual(code, "XYZ")
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2, buffer=True)

--- a/pychado/tests/io_gff_tests.py
+++ b/pychado/tests/io_gff_tests.py
@@ -36,7 +36,7 @@ class TestGFF(unittest.TestCase):
         dbutils.drop_database(cls.connection_uri, True)
 
     def setUp(self):
-        # Inserts default entries into database tables
+        # Creates a default GFF file entry
         self.default_gff_entry = gffutils.Feature(
             id="testid", seqid="testseqid", source="testsource", featuretype="testtype", start=1, end=30, score="3.5",
             strand="+", frame="2", attributes={
@@ -374,10 +374,10 @@ class TestGFF(unittest.TestCase):
         self.assertEqual(len(all_ontology_terms), 1)
 
     @unittest.mock.patch("pychado.io.gff.GFFImportClient._mark_feature_as_obsolete")
-    @unittest.mock.patch("pychado.io.gff.GFFImportClient._load_feature_ids")
+    @unittest.mock.patch("pychado.io.gff.GFFImportClient._load_feature_names")
     def test_mark_obsolete_features(self, mock_load: unittest.mock.Mock, mock_mark: unittest.mock.Mock):
         # Tests the function that marks features as obsolete if they are not present in a given dictionary
-        self.assertIs(mock_load, self.client._load_feature_ids)
+        self.assertIs(mock_load, self.client._load_feature_names)
         self.assertIs(mock_mark, self.client._mark_feature_as_obsolete)
         organism_entry = organism.Organism(genus="", species="", abbreviation="testorganism", organism_id=1)
         mock_load.return_value = ["id1", "id2", "id3", "seq"]

--- a/pychado/tests/io_gff_tests.py
+++ b/pychado/tests/io_gff_tests.py
@@ -81,6 +81,7 @@ class TestGFF(unittest.TestCase):
     @unittest.mock.patch("pychado.io.gff.GFFImportClient._has_fasta")
     def test_import_fasta(self, mock_includes: unittest.mock.Mock, mock_copy: unittest.mock.Mock,
                           mock_fasta: unittest.mock.Mock):
+        # Tests the function that imports the FASTA sequences for a GFF file
         self.assertIs(mock_includes, self.client._has_fasta)
         self.assertIs(mock_copy, self.client._split_off_fasta)
         self.assertIs(mock_fasta, fasta.FastaImportClient)
@@ -88,13 +89,13 @@ class TestGFF(unittest.TestCase):
         # FASTA in GFF and separate file
         mock_includes.return_value = True
         with self.assertRaises(iobase.InputFileError):
-            self.client._import_fasta("testgff", "testfasta", "testorganism")
+            self.client._import_fasta("testgff", "testfasta", "testorganism", "region")
 
         # FASTA in separate file only
         mock_includes.return_value = False
         mock_copy.reset_mock()
         mock_fasta.reset_mock()
-        self.client._import_fasta("testgff", "testfasta", "testorganism")
+        self.client._import_fasta("testgff", "testfasta", "testorganism", "region")
         mock_includes.assert_called_with("testgff")
         mock_copy.assert_not_called()
         mock_fasta.assert_called_with(self.client.uri, self.client.verbose)
@@ -104,7 +105,7 @@ class TestGFF(unittest.TestCase):
         mock_includes.return_value = True
         mock_copy.reset_mock()
         mock_fasta.reset_mock()
-        self.client._import_fasta("testgff", "", "testorganism")
+        self.client._import_fasta("testgff", "", "testorganism", "region")
         mock_includes.assert_called_with("testgff")
         mock_copy.assert_called()
         mock_fasta.assert_called()
@@ -113,7 +114,7 @@ class TestGFF(unittest.TestCase):
         mock_includes.return_value = False
         mock_copy.reset_mock()
         mock_fasta.reset_mock()
-        self.client._import_fasta("testgff", "", "testorganism")
+        self.client._import_fasta("testgff", "", "testorganism", "region")
         mock_includes.assert_called_with("testgff")
         mock_copy.assert_not_called()
         mock_fasta.assert_not_called()

--- a/pychado/tests/orm_tests.py
+++ b/pychado/tests/orm_tests.py
@@ -899,6 +899,46 @@ class TestPublic(unittest.TestCase):
         with self.assertRaises(sqlalchemy.exc.IntegrityError):
             self.client.add_and_flush(obj)
 
+    # Test suite for the Chado 'feature_cvterm_pub' table
+    def add_feature_cvterm_pub_object(self) -> sequence.FeatureCvTermPub:
+        # Insert a random entry into the 'feature_cvterm_pub' table
+        feature_cvterm_obj = self.add_feature_cvterm_object()
+        pub_obj = self.add_pub_object()
+        feature_cvterm_pub_obj = sequence.FeatureCvTermPub(feature_cvterm_id=feature_cvterm_obj.feature_cvterm_id,
+                                                           pub_id=pub_obj.pub_id)
+        self.client.add_and_flush(feature_cvterm_pub_obj)
+        return feature_cvterm_pub_obj
+
+    def test_feature_cvterm_pub(self):
+        # Test adding a new 'feature_cvterm_pub' object to the database
+        existing_obj = self.add_feature_cvterm_pub_object()
+        self.assertIsNotNone(existing_obj.feature_cvterm_pub_id)
+        self.assertEqual(existing_obj.__tablename__, 'feature_cvterm_pub')
+
+    def test_feature_cvterm_pub_feature_cvterm_id_fkey(self):
+        # Test foreign key constraint on 'feature_cvterm_pub.feature_cvterm_id'
+        existing_obj = self.add_feature_cvterm_pub_object()
+        obj = sequence.FeatureCvTermPub(feature_cvterm_id=(existing_obj.feature_cvterm_id+100),
+                                        pub_id=existing_obj.pub_id)
+        with self.assertRaises(sqlalchemy.exc.IntegrityError):
+            self.client.add_and_flush(obj)
+
+    def test_feature_cvterm_pub_pub_id_fkey(self):
+        # Test foreign key constraint on 'feature_cvterm_pub.pub_id'
+        existing_obj = self.add_feature_cvterm_pub_object()
+        obj = sequence.FeatureCvTermPub(feature_cvterm_id=existing_obj.feature_cvterm_id,
+                                        pub_id=(existing_obj.pub_id+100))
+        with self.assertRaises(sqlalchemy.exc.IntegrityError):
+            self.client.add_and_flush(obj)
+
+    def test_feature_cvterm_pub_c1(self):
+        # Test unique constraint on 'feature_cvterm_pub.feature_cvterm_id', 'feature_cvterm_pub.pub_id'
+        existing_obj = self.add_feature_cvterm_pub_object()
+        obj = sequence.FeatureCvTermPub(feature_cvterm_id=existing_obj.feature_cvterm_id,
+                                        pub_id=existing_obj.pub_id)
+        with self.assertRaises(sqlalchemy.exc.IntegrityError):
+            self.client.add_and_flush(obj)
+
     # Test suite for the Chado 'feature_dbxref' table
     def add_feature_dbxref_object(self) -> sequence.FeatureDbxRef:
         # Insert a random entry into the 'feature_dbxref' table

--- a/pychado/tests/tasks_tests.py
+++ b/pychado/tests/tasks_tests.py
@@ -414,11 +414,11 @@ class TestTasks(unittest.TestCase):
         # Checks that the function importing a GFF file into the database is correctly called
         self.assertIs(mock_client, gff.GFFImportClient)
         args = ["chado", "import", "gff", "-f", "testfile", "-a", "testorganism", "--fasta", "testfasta",
-                "--fresh_load", "--force", "--full_genome", "testdb"]
+                "-t", "contig", "--fresh_load", "--force", "--full_genome", "testdb"]
         parsed_args = chado_tools.parse_arguments(args)
         tasks.run_import_command(args[2], parsed_args, self.uri)
         mock_client.assert_called_with(self.uri, False)
-        self.assertIn(unittest.mock.call().load("testfile", "testorganism", "testfasta", True, True, True),
+        self.assertIn(unittest.mock.call().load("testfile", "testorganism", "testfasta", "contig", True, True, True),
                       mock_client.mock_calls)
 
     @unittest.mock.patch('pychado.io.fasta.FastaImportClient')

--- a/pychado/tests/tasks_tests.py
+++ b/pychado/tests/tasks_tests.py
@@ -1,6 +1,6 @@
 import unittest.mock
 from .. import chado_tools, tasks, queries, dbutils, utils, ddl
-from ..io import direct, essentials, ontology, fasta, gff
+from ..io import direct, essentials, ontology, fasta, gff, gaf
 
 
 class TestTasks(unittest.TestCase):
@@ -430,6 +430,16 @@ class TestTasks(unittest.TestCase):
         tasks.run_import_command(args[2], parsed_args, self.uri)
         mock_client.assert_called_with(self.uri, False)
         self.assertIn(unittest.mock.call().load("testfile", "testorganism", "contig"), mock_client.mock_calls)
+
+    @unittest.mock.patch('pychado.io.gaf.GAFImportClient')
+    def test_import_gaf(self, mock_client):
+        # Checks that the function importing a GAF file into the database is correctly called
+        self.assertIs(mock_client, gaf.GAFImportClient)
+        args = ["chado", "import", "gaf", "-f", "testfile", "-a", "testorganism", "testdb"]
+        parsed_args = chado_tools.parse_arguments(args)
+        tasks.run_import_command(args[2], parsed_args, self.uri)
+        mock_client.assert_called_with(self.uri, False)
+        self.assertIn(unittest.mock.call().load("testfile", "testorganism"), mock_client.mock_calls)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
- added missing ORM for table 'feature_cvterm_pub'
- chado import essentials: load additional terms
- option to import data from a GAF file as 'chado import gaf'
- specify FASTA sequence type when loading GFF
- chado admin grant: consider 'graph' schema
- cleaned up README