### PR TITLE
Protein

### DIFF
--- a/pychado/ddl.py
+++ b/pychado/ddl.py
@@ -115,7 +115,7 @@ class RolesClient(DDLClient):
         if specific_schema:
             schemata = [specific_schema]
         else:
-            schemata = ["public", "audit", "graph"]
+            schemata = ["public", "audit", "audit_backup", "graph"]
 
         # Loop over all schemata
         for schema in schemata:
@@ -150,7 +150,7 @@ class RolesClient(DDLClient):
             statements.append(" ".join(["GRANT EXECUTE ON ALL FUNCTIONS IN SCHEMA", x_schema, "TO", x_role]))
             statements.append(" ".join(["GRANT USAGE ON ALL SEQUENCES IN SCHEMA", x_schema, "TO", x_role]))
             statements.append(" ".join(["GRANT INSERT ON ALL TABLES IN SCHEMA", x_schema, "TO", x_role]))
-            if schema != "audit":
+            if not schema.startswith("audit"):
                 statements.append(" ".join(["GRANT UPDATE ON ALL TABLES IN SCHEMA", x_schema, "TO", x_role]))
                 statements.append(" ".join(["GRANT DELETE ON ALL TABLES IN SCHEMA", x_schema, "TO", x_role]))
         return statements

--- a/pychado/io/iobase.py
+++ b/pychado/io/iobase.py
@@ -93,7 +93,7 @@ class IOClient(ddl.ChadoClient):
     def query_parent_feature(self, child_name: str) -> sqlalchemy.orm.Query:
         """Creates a query to select the parent feature of a given feature"""
         subject_feature = sqlalchemy.orm.aliased(sequence.Feature, name="subject_feature")
-        object_feature  = sqlalchemy.orm.aliased(sequence.Feature, name="object_feature")
+        object_feature = sqlalchemy.orm.aliased(sequence.Feature, name="object_feature")
         return self.session.query(object_feature)\
             .select_from(sequence.FeatureRelationship)\
             .join(subject_feature, sequence.FeatureRelationship.subject)\
@@ -101,6 +101,7 @@ class IOClient(ddl.ChadoClient):
             .join(cv.CvTerm, sequence.FeatureRelationship.type)\
             .filter(cv.CvTerm.name == "part_of")\
             .filter(subject_feature.uniquename == child_name)
+
 
 class ImportClient(IOClient):
     """Base class for importing data into a CHADO database"""

--- a/pychado/io/iobase.py
+++ b/pychado/io/iobase.py
@@ -90,6 +90,17 @@ class IOClient(ddl.ChadoClient):
             .filter(sequence.FeatureCvTerm.feature_id == feature_id)\
             .filter(general.Db.name.in_(ontologies))
 
+    def query_parent_feature(self, child_name: str) -> sqlalchemy.orm.Query:
+        """Creates a query to select the parent feature of a given feature"""
+        subject_feature = sqlalchemy.orm.aliased(sequence.Feature, name="subject_feature")
+        object_feature  = sqlalchemy.orm.aliased(sequence.Feature, name="object_feature")
+        return self.session.query(object_feature)\
+            .select_from(sequence.FeatureRelationship)\
+            .join(subject_feature, sequence.FeatureRelationship.subject)\
+            .join(object_feature, sequence.FeatureRelationship.object)\
+            .join(cv.CvTerm, sequence.FeatureRelationship.type)\
+            .filter(cv.CvTerm.name == "part_of")\
+            .filter(subject_feature.uniquename == child_name)
 
 class ImportClient(IOClient):
     """Base class for importing data into a CHADO database"""

--- a/pychado/orm/sequence.py
+++ b/pychado/orm/sequence.py
@@ -536,7 +536,7 @@ class FeatureLoc(base.PublicBase):
     srcfeature = sqlalchemy.orm.relationship(Feature, foreign_keys=feature_id, backref="featureloc_srcfeature")
 
     # Initialisation
-    def __init__(self, feature_id, srcfeature_id, fmin=0, is_fmin_partial=False, fmax=0, is_fmax_partial=False,
+    def __init__(self, feature_id, srcfeature_id, fmin=None, is_fmin_partial=False, fmax=None, is_fmax_partial=False,
                  strand=None, phase=None, residue_info=None, locgroup=0, rank=0, featureloc_id=None):
         for key, value in locals().items():
             if key != self:

--- a/pychado/tests/io_base_tests.py
+++ b/pychado/tests/io_base_tests.py
@@ -128,7 +128,6 @@ class TestIOClient(unittest.TestCase):
         # Tests the function that creates a query against the feature_relationship table
         query = self.client.query_parent_feature("testname")
         compiled_query = str(query.statement.compile(compile_kwargs={"literal_binds": True}))
-
         self.assertIn("FROM public.feature_relationship JOIN public.feature AS subject_feature "
                       "ON subject_feature.feature_id = public.feature_relationship.subject_id "
                       "JOIN public.feature AS object_feature "
@@ -137,6 +136,7 @@ class TestIOClient(unittest.TestCase):
                       "ON public.cvterm.cvterm_id = public.feature_relationship.type_id", compiled_query)
         self.assertIn("public.cvterm.name = 'part_of'", compiled_query)
         self.assertIn("subject_feature.uniquename = 'testname'", compiled_query)
+
 
 class TestImportClient(unittest.TestCase):
     """Test functions for loading data into a CHADO database"""

--- a/pychado/tests/io_base_tests.py
+++ b/pychado/tests/io_base_tests.py
@@ -124,6 +124,19 @@ class TestIOClient(unittest.TestCase):
         self.assertIn("feature_cvterm.feature_id = 12", compiled_query)
         self.assertIn("db.name IN ('testontology')", compiled_query)
 
+    def test_query_parent_feature(self):
+        # Tests the function that creates a query against the feature_relationship table
+        query = self.client.query_parent_feature("testname")
+        compiled_query = str(query.statement.compile(compile_kwargs={"literal_binds": True}))
+
+        self.assertIn("FROM public.feature_relationship JOIN public.feature AS subject_feature "
+                      "ON subject_feature.feature_id = public.feature_relationship.subject_id "
+                      "JOIN public.feature AS object_feature "
+                      "ON object_feature.feature_id = public.feature_relationship.object_id "
+                      "JOIN public.cvterm "
+                      "ON public.cvterm.cvterm_id = public.feature_relationship.type_id", compiled_query)
+        self.assertIn("public.cvterm.name = 'part_of'", compiled_query)
+        self.assertIn("subject_feature.uniquename = 'testname'", compiled_query)
 
 class TestImportClient(unittest.TestCase):
     """Test functions for loading data into a CHADO database"""


### PR DESCRIPTION
- consider attribute "protein_source_id" in GFF records by creating a separate Feature in Chado
- slight restructuring of GFF import class with more consistent variable names
- consider schema "audit_backup" when granting privileges