### PR TITLE
import/export fixes

### DIFF
--- a/pychado/io/fasta.py
+++ b/pychado/io/fasta.py
@@ -153,7 +153,13 @@ class FastaExportClient(iobase.ChadoClient):
                 records.append(record)
 
         # Write all FASTA records to file
+        records.sort(key=self._sort_record_key)
         SeqIO.write(records, filename, "fasta")
+
+    @staticmethod
+    def _sort_record_key(record: SeqIO.SeqRecord):
+        """Helper function for sorting records"""
+        return record.id
 
     def _create_fasta_record(self, feature_entry: sequence.Feature, organism_entry: organism.Organism,
                              type_entry: cv.CvTerm, residues: str, release: str, extract_version: bool
@@ -236,6 +242,11 @@ class FastaExportClient(iobase.ChadoClient):
             residues = matching_entry.residues[featureloc_entry.fmin:featureloc_entry.fmax].upper()
         else:
             residues = None
+
+        # Compute the complementary sequence, if necessary
+        if residues and featureloc_entry.strand < 0:
+            sequence_object = Seq.Seq(residues, alphabet=Seq.IUPAC.ambiguous_dna)
+            residues = str(sequence_object.reverse_complement())
         return residues
 
     def _create_fasta_attributes(self, organism_entry: organism.Organism, type_entry: cv.CvTerm, release: str,

--- a/pychado/io/gff.py
+++ b/pychado/io/gff.py
@@ -406,10 +406,15 @@ class GFFImportClient(iobase.ChadoClient, GFFClient):
             for parent in parents:
 
                 # Get database entry for object
-                if parent not in all_features:
-                    self.printer.print("WARNING: Feature '" + parent + "' not present in input file.")
+                if parent in all_features:
+                    object_entry = all_features[parent]
+                else:
+                    object_entry = self.query_first(sequence.Feature, organism_id=subject_entry.organism_id,
+                                                    uniquename=parent)
+                if not object_entry:
+                    self.printer.print("WARNING: Feature '" + parent +
+                                       "' neither present in input file nor in database.")
                     continue
-                object_entry = all_features[parent]
 
                 # Insert/update entry in the 'feature_relationship' table
                 new_relationship_entry = sequence.FeatureRelationship(subject_id=subject_entry.feature_id,

--- a/pychado/tests/io_fasta_tests.py
+++ b/pychado/tests/io_fasta_tests.py
@@ -138,7 +138,7 @@ class TestFastaExport(unittest.TestCase):
         self.assertIs(mock_query, self.client.query_first)
         feature_entry = sequence.Feature(organism_id=1, type_id=2, uniquename="test", residues="CTGA", feature_id=33)
 
-        mock_query.return_value = sequence.FeatureLoc(feature_id=33, srcfeature_id=34, fmin=1, fmax=3)
+        mock_query.return_value = sequence.FeatureLoc(feature_id=33, srcfeature_id=34, fmin=1, fmax=3, strand=1)
         residues = self.client._extract_nucleotide_sequence(feature_entry, [])
         mock_query.assert_called_with(sequence.FeatureLoc, feature_id=33)
         self.assertIsNone(residues)
@@ -147,6 +147,10 @@ class TestFastaExport(unittest.TestCase):
                                                feature_id=34)]
         residues = self.client._extract_nucleotide_sequence(feature_entry, srcfeature_entries)
         self.assertEqual(residues, "CT")
+
+        mock_query.return_value = sequence.FeatureLoc(feature_id=33, srcfeature_id=34, fmin=0, fmax=6, strand=-1)
+        residues = self.client._extract_nucleotide_sequence(feature_entry, srcfeature_entries)
+        self.assertEqual(residues, "ACCAGT")
 
         mock_query.return_value = sequence.FeatureLoc(feature_id=33, srcfeature_id=34, fmin=1, fmax=300)
         residues = self.client._extract_nucleotide_sequence(feature_entry, srcfeature_entries)

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ except FileNotFoundError or FileExistsError:
 
 setuptools.setup(
     name="chado-tools",
-    version="0.2.3",
+    version="0.2.4",
     author="Christoph Puethe",
     author_email="path-help@sanger.ac.uk",
     description="Tools to access CHADO databases",


### PR DESCRIPTION
- FASTA export for genes: For genes located on the "-" strand, export the reversed complementary sequence
- GAF export: Set defaults for missing evidence codes
- GFF import: query database for parent features not present in input file 
- adapt tests