### PR TITLE
exclude obsolete features when exporting GFF, GAF or FASTA by default…

### DIFF
--- a/pychado/chado_tools.py
+++ b/pychado/chado_tools.py
@@ -511,6 +511,7 @@ def add_export_fasta_arguments(parser: argparse.ArgumentParser):
                         help="type of the sequences to be exported")
     parser.add_argument("-r", "--release", help="name of the FASTA release")
     parser.add_argument("--extract_version", action="store_true", help="extract the genome version, if available")
+    parser.add_argument("--include_obsolete", action="store_true", help="export all features, including obsoletes")
 
 
 def add_export_gff_arguments(parser: argparse.ArgumentParser):
@@ -520,6 +521,7 @@ def add_export_gff_arguments(parser: argparse.ArgumentParser):
                         help="abbreviation/short name of the organism")
     parser.add_argument("--export_fasta", action="store_true", help="export FASTA sequences along with annotations")
     parser.add_argument("--fasta_file", help="FASTA output file with sequences (default: paste to end of GFF file)")
+    parser.add_argument("--include_obsolete", action="store_true", help="export all features, including obsoletes")
 
 
 def add_export_gaf_arguments(parser: argparse.ArgumentParser):
@@ -532,3 +534,4 @@ def add_export_gaf_arguments(parser: argparse.ArgumentParser):
     parser.add_argument("-L", "--annotation_level", choices=["default", "gene", "transcript", "protein"],
                         default="default", help="level to which GO terms are related in the output file (default: "
                                                 "same level as in the database)")
+    parser.add_argument("--include_obsolete", action="store_true", help="export all features, including obsoletes")

--- a/pychado/io/fasta.py
+++ b/pychado/io/fasta.py
@@ -130,7 +130,8 @@ class FastaExportClient(iobase.ChadoClient):
         self._derives_from_term = self._load_cvterm_from_cv("derives_from", "sequence")
         self._top_level_term = self._load_cvterm("top_level_seq")
 
-    def export(self, filename: str, organism_name: str, sequence_type: str, release: str, extract_version=False):
+    def export(self, filename: str, organism_name: str, sequence_type: str, release: str, extract_version=False,
+               include_obsolete_features=False):
         """Exports sequences from Chado to a FASTA file"""
 
         # Load dependencies and features of interest
@@ -147,7 +148,8 @@ class FastaExportClient(iobase.ChadoClient):
 
             # Create FASTA record
             residues = self._extract_residues_by_type(feature_entry, srcfeature_entries, sequence_type)
-            if self._are_residues_valid(residues, sequence_type):
+            if self._are_residues_valid(residues, sequence_type) and \
+                    (include_obsolete_features or not feature_entry.is_obsolete):
                 record = self._create_fasta_record(feature_entry, organism_entry, type_entry, residues, release,
                                                    extract_version)
                 records.append(record)

--- a/pychado/tasks.py
+++ b/pychado/tasks.py
@@ -220,13 +220,14 @@ def run_export_command(specifier: str, arguments, uri: str) -> None:
     if specifier == "fasta":
         client = fasta.FastaExportClient(uri, arguments.verbose)
         client.export(arguments.output_file, arguments.organism, arguments.sequence_type, arguments.release,
-                      arguments.extract_version)
+                      arguments.extract_version, arguments.include_obsolete)
     elif specifier == "gff":
         client = gff.GFFExportClient(uri, arguments.verbose)
-        client.export(arguments.output_file, arguments.organism, arguments.export_fasta, arguments.fasta_file)
+        client.export(arguments.output_file, arguments.organism, arguments.export_fasta, arguments.fasta_file,
+                      arguments.include_obsolete)
     elif specifier == "gaf":
         client = gaf.GAFExportClient(uri, arguments.verbose)
         client.export(arguments.output_file, arguments.organism, arguments.database_authority,
-                      arguments.annotation_level)
+                      arguments.annotation_level, arguments.include_obsolete)
     else:
         print("Functionality 'export " + specifier + "' is not yet implemented.")

--- a/pychado/tests/arguments_tests.py
+++ b/pychado/tests/arguments_tests.py
@@ -349,6 +349,7 @@ class TestArguments(unittest.TestCase):
         self.assertEqual(parsed_args["sequence_type"], "proteins")
         self.assertEqual(parsed_args["release"], "testrelease")
         self.assertFalse(parsed_args["extract_version"])
+        self.assertFalse(parsed_args["include_obsolete"])
         self.assertEqual(parsed_args["dbname"], "testdb")
 
     def test_export_gff_args(self):
@@ -360,6 +361,7 @@ class TestArguments(unittest.TestCase):
         self.assertEqual(parsed_args["organism"], "testorganism")
         self.assertTrue(parsed_args["export_fasta"])
         self.assertEqual(parsed_args["fasta_file"], "testfasta")
+        self.assertFalse(parsed_args["include_obsolete"])
         self.assertEqual(parsed_args["dbname"], "testdb")
 
     def test_export_gaf_args(self):
@@ -371,6 +373,7 @@ class TestArguments(unittest.TestCase):
         self.assertEqual(parsed_args["organism"], "testorganism")
         self.assertEqual(parsed_args["database_authority"], "testauthority")
         self.assertEqual(parsed_args["annotation_level"], "protein")
+        self.assertFalse(parsed_args["include_obsolete"])
         self.assertEqual(parsed_args["dbname"], "testdb")
 
 

--- a/pychado/tests/tasks_tests.py
+++ b/pychado/tests/tasks_tests.py
@@ -512,7 +512,7 @@ class TestTasks(unittest.TestCase):
         parsed_args = chado_tools.parse_arguments(args)
         tasks.run_export_command(args[2], parsed_args, self.uri)
         mock_client.assert_called_with(self.uri, False)
-        self.assertIn(unittest.mock.call().export("testfile", "testorganism", "proteins", "testrelease", False),
+        self.assertIn(unittest.mock.call().export("testfile", "testorganism", "proteins", "testrelease", False, False),
                       mock_client.mock_calls)
 
     @unittest.mock.patch('pychado.io.gff.GFFExportClient')
@@ -524,7 +524,7 @@ class TestTasks(unittest.TestCase):
         parsed_args = chado_tools.parse_arguments(args)
         tasks.run_export_command(args[2], parsed_args, self.uri)
         mock_client.assert_called_with(self.uri, False)
-        self.assertIn(unittest.mock.call().export("testfile", "testorganism", True, "testfasta"),
+        self.assertIn(unittest.mock.call().export("testfile", "testorganism", True, "testfasta", False),
                       mock_client.mock_calls)
 
     @unittest.mock.patch('pychado.io.gaf.GAFExportClient')
@@ -536,7 +536,7 @@ class TestTasks(unittest.TestCase):
         parsed_args = chado_tools.parse_arguments(args)
         tasks.run_export_command(args[2], parsed_args, self.uri)
         mock_client.assert_called_with(self.uri, False)
-        self.assertIn(unittest.mock.call().export("testfile", "testorganism", "testauthority", "protein"),
+        self.assertIn(unittest.mock.call().export("testfile", "testorganism", "testauthority", "protein", False),
                       mock_client.mock_calls)
 
 

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ except FileNotFoundError or FileExistsError:
 
 setuptools.setup(
     name="chado-tools",
-    version="0.2.4",
+    version="0.2.5",
     author="Christoph Puethe",
     author_email="path-help@sanger.ac.uk",
     description="Tools to access CHADO databases",


### PR DESCRIPTION
…; set flag --include_obsolete to override