### PR TITLE
chado extract comments

### DIFF
--- a/pychado/chado_tools.py
+++ b/pychado/chado_tools.py
@@ -83,7 +83,8 @@ def extract_commands() -> dict:
         "organisms": "list all organisms in the CHADO database",
         "cvterms": "list all CV terms in the CHADO database",
         "genedb_products": "list all products of transcripts in the CHADO database",
-        "stats": "obtain statistics to updates in a CHADO database"
+        "stats": "obtain statistics to updates in a CHADO database",
+        "comments": "list curator comments to genes and gene products in a CHADO database"
     }
 
 
@@ -320,6 +321,8 @@ def add_extract_arguments_by_command(command: str, parser: argparse.ArgumentPars
         add_extract_genedb_product_arguments(parser)
     elif command == "stats":
         add_extract_stats_arguments(parser)
+    elif command == "comments":
+        add_extract_comments_arguments(parser)
     else:
         print("Command '" + parser.prog + "' is not available.")
 
@@ -349,6 +352,11 @@ def add_extract_stats_arguments(parser: argparse.ArgumentParser):
     parser.add_argument("--start_date", required=True, help="date for maximum age of updates, format 'YYYYMMDD'")
     parser.add_argument("--end_date", default="", help="date for minimum age of updates, format 'YYYYMMDD' "
                                                        "(default: today)")
+
+def add_extract_comments_arguments(parser: argparse.ArgumentParser):
+    """Defines formal arguments for the 'chado extract comments' sub-command"""
+    parser.add_argument("-a", "--abbreviation", dest="organism",
+                        help="restrict to a certain organism, defined by its abbreviation/short name (default: all)")
 
 
 def add_insert_arguments(parser: argparse.ArgumentParser):

--- a/pychado/queries.py
+++ b/pychado/queries.py
@@ -14,6 +14,8 @@ def load_query(specifier: str) -> str:
         query = utils.read_text(pkg_resources.resource_filename("pychado", "sql/extract_genedb_products.sql"))
     elif specifier == "stats":
         query = utils.read_text(pkg_resources.resource_filename("pychado", "sql/extract_stats.sql"))
+    elif specifier == "comments":
+        query = utils.read_text(pkg_resources.resource_filename("pychado", "sql/extract_comments.sql"))
     return query
 
 

--- a/pychado/sql/extract_comments.sql
+++ b/pychado/sql/extract_comments.sql
@@ -1,0 +1,34 @@
+/*
+ * This query returns a list of all curator comments on genes and gene products
+ */
+SELECT
+    feature2.uniquename AS gene_id,
+	feature1.uniquename AS transcript_id,
+	featureprop.value AS curator_comment
+FROM
+    featureprop                                                                     -- start off with a gene product (e.g. polypeptide)
+	JOIN
+	feature_relationship relation1 ON featureprop.feature_id = relation1.subject_id	-- connect gene product...
+	JOIN
+	feature feature1 ON relation1.object_id = feature1.feature_id					-- ... with transcript from which it derives
+	JOIN
+	feature_relationship relation2 ON relation2.subject_id = feature1.feature_id	-- connect transcript...
+	JOIN
+	feature feature2 ON relation2.object_id = feature2.feature_id					-- ... with the corresponding gene
+	JOIN
+	organism ON feature2.organism_id = organism.organism_id                         -- finally connect with the organism
+WHERE
+	featureprop.type_id IN (SELECT cvterm_id FROM cvterm WHERE name IN ('comment', 'curation'))  -- restrict to curator comments
+	AND
+	feature2.type_id IN (SELECT cvterm_id FROM cvterm WHERE name IN ('gene', 'pseudogene'))  -- restrict to feature types
+	AND
+	relation1.type_id IN (SELECT cvterm_id FROM cvterm WHERE name = 'derives_from')	-- gene product 'derives from' transcript
+	AND
+	relation2.type_id IN (SELECT cvterm_id FROM cvterm WHERE name = 'part_of')	    -- transcript is 'part of' gene, at least in the Sanger pathogen DBs
+	AND
+	:ORGANISM_CONDITION                                                             -- a specific organism, or all
+	AND
+	feature2.is_obsolete = 'f'														-- ignore obsolete features
+ORDER BY
+	gene_id,
+	transcript_id

--- a/pychado/sql/extract_comments.sql
+++ b/pychado/sql/extract_comments.sql
@@ -31,4 +31,5 @@ WHERE
 	feature2.is_obsolete = 'f'														-- ignore obsolete features
 ORDER BY
 	gene_id,
-	transcript_id
+	transcript_id,
+	curator_comment

--- a/pychado/tasks.py
+++ b/pychado/tasks.py
@@ -159,6 +159,8 @@ def run_select_command(specifier: str, arguments, uri: str) -> None:
         elif specifier == "stats":
             query = queries.set_query_conditions(template, organism=arguments.organism, start_date=arguments.start_date,
                                                  end_date=(arguments.end_date or utils.current_date()))
+        elif specifier == "comments":
+            query = queries.set_query_conditions(template, organism=arguments.organism)
         else:
             print("Functionality 'extract " + specifier + "' is not yet implemented.")
             query = queries.set_query_conditions("")

--- a/pychado/tests/arguments_tests.py
+++ b/pychado/tests/arguments_tests.py
@@ -41,11 +41,12 @@ class TestCommands(unittest.TestCase):
 
     def test_extract_commands(self):
         commands = chado_tools.extract_commands()
-        self.assertEqual(len(commands), 4)
+        self.assertEqual(len(commands), 5)
         self.assertIn("organisms", commands)
         self.assertIn("cvterms", commands)
         self.assertIn("genedb_products", commands)
         self.assertIn("stats", commands)
+        self.assertIn("comments", commands)
 
     def test_insert_commands(self):
         commands = chado_tools.insert_commands()
@@ -245,6 +246,18 @@ class TestArguments(unittest.TestCase):
     def test_extract_genedb_products_args(self):
         # Tests if the command line arguments for the subcommand 'chado extract genedb_products' are parsed correctly
         args = ["chado", "extract", "genedb_products", "-H", "-d", ";", "-o", "testfile", "-a", "testorganism",
+                "testdb"]
+        parsed_args = vars(chado_tools.parse_arguments(args))
+        self.assertTrue(parsed_args["include_header"])
+        self.assertEqual(parsed_args["delimiter"], ";")
+        self.assertEqual(parsed_args["output_file"], "testfile")
+        self.assertEqual(parsed_args["format"], "csv")
+        self.assertEqual(parsed_args["organism"], "testorganism")
+        self.assertEqual(parsed_args["dbname"], "testdb")
+
+    def test_extract_comments_args(self):
+        # Tests if the command line arguments for the subcommand 'chado extract comments' are parsed correctly
+        args = ["chado", "extract", "comments", "-H", "-d", ";", "-o", "testfile", "-a", "testorganism",
                 "testdb"]
         parsed_args = vars(chado_tools.parse_arguments(args))
         self.assertTrue(parsed_args["include_header"])

--- a/pychado/tests/queries_tests.py
+++ b/pychado/tests/queries_tests.py
@@ -28,6 +28,9 @@ class TestQueries(unittest.TestCase):
         query = queries.load_query("stats")
         self.assertIn("SELECT", query)
 
+        query = queries.load_query("comments")
+        self.assertIn("SELECT", query)
+
         query = queries.load_query("non_existent_specifier")
         self.assertEqual(query, "")
 

--- a/pychado/tests/tasks_tests.py
+++ b/pychado/tests/tasks_tests.py
@@ -368,6 +368,26 @@ class TestTasks(unittest.TestCase):
         mock_set.assert_called_with("testquery", organism="testorganism")
         mock_query.assert_called_with(self.uri, "testquery_with_params", "", "csv", False, "\t")
 
+    @unittest.mock.patch('pychado.dbutils.query_and_print')
+    @unittest.mock.patch('pychado.queries.set_query_conditions')
+    @unittest.mock.patch('pychado.queries.load_query')
+    def test_extract_comments(self, mock_load, mock_set, mock_query):
+        # Checks that the function extracting comments on features is correctly called
+        self.assertIs(mock_load, queries.load_query)
+        self.assertIs(mock_set, queries.set_query_conditions)
+        self.assertIs(mock_query, dbutils.query_and_print)
+
+        args = ["chado", "extract", "comments", "-a", "testorganism", "testdb"]
+        parsed_args = chado_tools.parse_arguments(args)
+        mock_load.return_value = "testquery"
+        mock_set.return_value = "testquery_with_params"
+        mock_query.return_value = ['a', 'b', 'c']
+
+        tasks.run_select_command(args[2], parsed_args, self.uri)
+        mock_load.assert_called_with("comments")
+        mock_set.assert_called_with("testquery", organism="testorganism")
+        mock_query.assert_called_with(self.uri, "testquery_with_params", "", "csv", False, "\t")
+
     @unittest.mock.patch('pychado.tasks.run_insert_command')
     def test_run_insert(self, mock_run):
         # Checks that database inserts are correctly run

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ except FileNotFoundError or FileExistsError:
 
 setuptools.setup(
     name="chado-tools",
-    version="0.2.5",
+    version="0.2.6",
     author="Christoph Puethe",
     author_email="path-help@sanger.ac.uk",
     description="Tools to access CHADO databases",


### PR DESCRIPTION
simple function to extract curator comments on gene products for a specific organism
implemented analogously to 'chado extract genedb_products', i.e. using actual SQL instead of the ORM. This can/should be changed in the future.