### PR TITLE
Synonyms

### DIFF
--- a/pychado/chado_tools.py
+++ b/pychado/chado_tools.py
@@ -353,6 +353,7 @@ def add_extract_stats_arguments(parser: argparse.ArgumentParser):
     parser.add_argument("--end_date", default="", help="date for minimum age of updates, format 'YYYYMMDD' "
                                                        "(default: today)")
 
+
 def add_extract_comments_arguments(parser: argparse.ArgumentParser):
     """Defines formal arguments for the 'chado extract comments' sub-command"""
     parser.add_argument("-a", "--abbreviation", dest="organism",
@@ -465,7 +466,9 @@ def add_import_gff_arguments(parser: argparse.ArgumentParser):
     parser.add_argument("--force", action="store_true",
                         help="in case of a fresh load, purge all existing features of the organism")
     parser.add_argument("--full_genome", action="store_true",
-                        help="in case of an update, assume that the GFF file contains all features of the organism")
+                        help="in case of an update, mark features not present in the input file as obsolete")
+    parser.add_argument("--full_attributes", action="store_true",
+                        help="in case of an update, delete feature attributes not present in the input file")
 
 
 def add_import_fasta_arguments(parser: argparse.ArgumentParser):

--- a/pychado/orm/base.py
+++ b/pychado/orm/base.py
@@ -6,4 +6,4 @@ AuditBase = sqlalchemy.ext.declarative.declarative_base(metadata=sqlalchemy.sche
 
 # Define data types
 BIGINT = sqlalchemy.BIGINT().with_variant(sqlalchemy.INTEGER(), 'sqlite')
-operation_type = sqlalchemy.Enum('INSERT', 'UPDATE', 'DELETE', name='operation_type')
+operation_type = sqlalchemy.Enum('INSERT', 'UPDATE', 'DELETE', 'BEFORE', name='operation_type')

--- a/pychado/orm/sequence.py
+++ b/pychado/orm/sequence.py
@@ -493,7 +493,7 @@ class FeatureSynonym(base.PublicBase):
     pub = sqlalchemy.orm.relationship(pub.Pub, foreign_keys=pub_id, backref="feature_synonym_pub")
 
     # Initialisation
-    def __init__(self, synonym_id, feature_id, pub_id, is_current=True, is_internal=False, feature_synonym_id=None):
+    def __init__(self, synonym_id, feature_id, pub_id, is_current=None, is_internal=None, feature_synonym_id=None):
         for key, val in locals().items():
             if key != self:
                 setattr(self, key, val)

--- a/pychado/tasks.py
+++ b/pychado/tasks.py
@@ -206,7 +206,7 @@ def run_import_command(specifier: str, arguments, uri: str) -> None:
     elif specifier == "gff":
         client = gff.GFFImportClient(uri, arguments.verbose)
         client.load(file, arguments.organism, arguments.fasta, arguments.sequence_type, arguments.fresh_load,
-                    arguments.force, arguments.full_genome)
+                    arguments.force, arguments.full_genome, arguments.full_attributes)
     elif specifier == "fasta":
         client = fasta.FastaImportClient(uri, arguments.verbose)
         client.load(file, arguments.organism, arguments.sequence_type)

--- a/pychado/tests/arguments_tests.py
+++ b/pychado/tests/arguments_tests.py
@@ -315,7 +315,7 @@ class TestArguments(unittest.TestCase):
     def test_import_gff_args(self):
         # Tests if the command line arguments for the subcommand 'chado import gff' are parsed correctly
         args = ["chado", "import", "gff", "-f", "testfile", "-a", "testorganism", "--fasta", "testfasta",
-                "-t", "contig", "--fresh_load", "--force", "--full_genome", "testdb"]
+                "-t", "contig", "--fresh_load", "--force", "--full_genome", "--full_attributes", "testdb"]
         parsed_args = vars(chado_tools.parse_arguments(args))
         self.assertEqual(parsed_args["input_file"], "testfile")
         self.assertEqual(parsed_args["organism"], "testorganism")
@@ -324,6 +324,7 @@ class TestArguments(unittest.TestCase):
         self.assertTrue(parsed_args["fresh_load"])
         self.assertTrue(parsed_args["force"])
         self.assertTrue(parsed_args["full_genome"])
+        self.assertTrue(parsed_args["full_attributes"])
         self.assertEqual(parsed_args["dbname"], "testdb")
 
         # Test the default values / alternatives
@@ -333,6 +334,7 @@ class TestArguments(unittest.TestCase):
         self.assertFalse(parsed_args["fresh_load"])
         self.assertFalse(parsed_args["force"])
         self.assertFalse(parsed_args["full_genome"])
+        self.assertFalse(parsed_args["full_attributes"])
 
     def test_import_fasta_args(self):
         # Tests if the command line arguments for the subcommand 'chado import fasta' are parsed correctly

--- a/pychado/tests/ddl_tests.py
+++ b/pychado/tests/ddl_tests.py
@@ -142,7 +142,13 @@ class SetupTests(unittest.TestCase):
     def test_generic_audit_function(self):
         # Tests the syntax of an audit function
         fct = self.client.generic_audit_function("testschema", "testtable", ["col1", "col2"])
-        self.assertEqual(fct, "IF TG_OP = 'INSERT' OR TG_OP = 'UPDATE' THEN\n"
+        self.assertEqual(fct, "IF TG_OP = 'INSERT' THEN\n"
+                              "\tINSERT INTO testschema.testtable(type, col1, col2) "
+                              "VALUES (CAST(TG_OP AS operation_type), NEW.col1, NEW.col2);\n"
+                              "\tRETURN NEW;\n"
+                              "ELSIF TG_OP = 'UPDATE' THEN\n"
+                              "\tINSERT INTO testschema.testtable(type, col1, col2) "
+                              "VALUES (CAST('BEFORE' AS operation_type), OLD.col1, OLD.col2);\n"
                               "\tINSERT INTO testschema.testtable(type, col1, col2) "
                               "VALUES (CAST(TG_OP AS operation_type), NEW.col1, NEW.col2);\n"
                               "\tRETURN NEW;\n"

--- a/pychado/tests/tasks_tests.py
+++ b/pychado/tests/tasks_tests.py
@@ -491,8 +491,8 @@ class TestTasks(unittest.TestCase):
         parsed_args = chado_tools.parse_arguments(args)
         tasks.run_import_command(args[2], parsed_args, self.uri)
         mock_client.assert_called_with(self.uri, False)
-        self.assertIn(unittest.mock.call().load("testfile", "testorganism", "testfasta", "contig", True, True, True),
-                      mock_client.mock_calls)
+        self.assertIn(unittest.mock.call().load("testfile", "testorganism", "testfasta", "contig",
+                                                True, True, True, False), mock_client.mock_calls)
 
     @unittest.mock.patch('pychado.io.fasta.FastaImportClient')
     def test_import_fasta(self, mock_client):

--- a/pychado/tests/utils_tests.py
+++ b/pychado/tests/utils_tests.py
@@ -89,6 +89,19 @@ class TestUtils(unittest.TestCase):
         self.assertIn("parasites and microbes", content["faculties"])
         self.assertNotIn("zebrafish genetics", content["faculties"])
 
+    def test_parse_string(self):
+        # checks if a string is parsed correctly
+        parsed = utils.parse_string("true")
+        self.assertTrue(parsed)
+        parsed = utils.parse_string("FALSE")
+        self.assertFalse(parsed)
+        parsed = utils.parse_string("765")
+        self.assertEqual(parsed, 765)
+        parsed = utils.parse_string("76.5")
+        self.assertEqual(parsed, 76.5)
+        parsed = utils.parse_string("ture")
+        self.assertEqual(parsed, "ture")
+
     def test_list_to_string(self):
         # checks if a list is correctly concatenated
         test_list = [1.123, None, 'hello', True, 'A', 8, False]

--- a/pychado/utils.py
+++ b/pychado/utils.py
@@ -117,6 +117,38 @@ def dump_yaml(filename: str, data: dict) -> None:
     close(stream)
 
 
+def parse_string(the_string: str):
+    """Converts a string to an integer/float/boolean, if applicable"""
+    if is_string_float(the_string):
+        return float(the_string)
+    elif is_string_integer(the_string):
+        return int(the_string)
+    elif the_string.lower() == "true":
+        return True
+    elif the_string.lower() == "false":
+        return False
+    else:
+        return the_string
+
+
+def is_string_integer(the_string: str) -> bool:
+    """Tests whether a string can be represented as integer number"""
+    try:
+        int(the_string)
+        return True
+    except ValueError:
+        return False
+
+
+def is_string_float(the_string: str) -> bool:
+    """Tests whether a string can be represented as floating-point number"""
+    try:
+        float(the_string)
+        return True
+    except ValueError:
+        return False
+
+
 def list_to_string(the_list: list, delimiter: str, prefix=None) -> str:
     """Function concatenating all elements of a list"""
     the_string = []

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ except FileNotFoundError or FileExistsError:
 
 setuptools.setup(
     name="chado-tools",
-    version="0.2.6",
+    version="0.2.7",
     author="Christoph Puethe",
     author_email="path-help@sanger.ac.uk",
     description="Tools to access CHADO databases",


### PR DESCRIPTION
- audit tables: add two lines for each UPDATE operation; one with the old, one with the new content
- by default do not delete feature attributes at GFF import
- new flag "--full_attributes" to delete feature attibutes at GFF import
- new function to parse "complex" GFF attributes (from Artemis exports)
- fix for GFF imports of synonyms with specifier "current=true/false"