### PR TITLE
Make containerisable

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,30 +27,27 @@ There are a number of ways to install chado-tools and details are provided below
 
 ### Required dependencies
 
-* Python 3.6 or higher
+* Python 3.6
 * PostgreSQL 9.6 or higher
 
 ### From source
 
 Download the latest release from this github repository, or clone the repository to obtain the most recent updates.
-
-Modify the file with [default connection settings](pychado/data/defaultDatabase.yml) such that it contains the settings for an existing PostgreSQL database server to which you can connect.
-
-Then run the tests:
-
-    python3 setup.py test
-
-If the tests all pass, install:
+Then install the software:
 
     python3 setup.py install
+
+NOTE: Some of the integration tests rely on temporary PostgreSQL databases. In order to successfully run those tests, 
+modify the [default connection settings](pychado/data/defaultDatabase.yml) such that they describe an existing 
+PostgreSQL database server to which you can connect. The tests can then be run as
+
+    python3 setup.py test
 
 ### Using pip
 
 You can install the program from the *Python Package Index (PyPI)* using the command
 
     pip install chado-tools
-
-Now change the default connection parameters by running `chado init`. You can always reset them to the original state by running `chado reset`.
 
 ### Using Bioconda
 
@@ -69,13 +66,30 @@ The usage is:
 * To display the version of the program, type `chado -v` or `chado --version`.
 * Use `chado <command> -h` or `chado <command> --help` to get a detailed description and the usage of that command.
 
+### Database connection
+
+You can set up default values for database host, port and user with environment variables. To do so, add the following 
+lines to your `.bashrc` (replacing the example values):
+
+    export CHADO_HOST=localhost
+    export CHADO_PORT=5432
+    export CHADO_USER=chadouser
+
+The software seeks for these environment variables on your system. If they do not exist, it will use the 
+[default connection settings](pychado/data/defaultDatabase.yml), which you can edit manually if you really want.
+
+By default the software will assume that no password is required to connect as the user specified as `CHADO_USER`. The 
+flag `-p` enforces asking the user for a password.
+
+Alternatively, you can supply your own YAML configuration file in the same format as the [default file](pychado/data/defaultDatabase.yml)
+with flag `-c` (including password). The software will then ignore any environment variables. 
+
+
 ### Available commands
 
 ------------------------------------------------------------------------------------------------
 | Command               | Description                                                          |
 |-----------------------|----------------------------------------------------------------------|
-| init                  | set the default connection parameters                                |
-| reset                 | reset the default connection parameters to factory settings          |
 | connect               | connect to a CHADO database for an interactive session               |
 | query                 | query a CHADO database and export the result into a text file        |
 | execute               | execute a function defined in a CHADO database                       |
@@ -106,10 +120,9 @@ Query the database to check the meaning of a certain `cvterm_id`:
 
     chado query -q "SELECT name FROM cvterm WHERE cvterm_id = 25" eukaryotes
 
-### Note
+Export a FASTA file containing the sequences of the organism `Pfalciparum`:
 
-Unless explicitly specified by the flag `-c`, all commands employ the [default connection settings](pychado/data/defaultDatabase.yml).
-You can change these by running `chado init`.
+    chado export fasta -a Pfalciparum -o Pfalciparum.fasta -t contigs eukaryotes
 
 ## License
 chado-tools is free software, licensed under [GPLv3](https://github.com/sanger-pathogens/chado-tools/blob/master/LICENSE).

--- a/pychado/data/factorySettings.yml
+++ b/pychado/data/factorySettings.yml
@@ -1,5 +1,0 @@
-database: postgres
-host:     localhost
-port:     5432
-user:     chado_user
-password: chado_pw

--- a/pychado/tasks.py
+++ b/pychado/tasks.py
@@ -2,15 +2,6 @@ from . import utils, dbutils, queries, ddl
 from .io import direct, essentials, ontology, fasta, gff, gaf
 
 
-def create_connection_string(filename: str, dbname: str) -> str:
-    """Reads database connection parameters from a configuration file and generates a connection string"""
-    if not filename:
-        filename = dbutils.default_configuration_file()
-    connection_parameters = utils.parse_yaml(filename)
-    connection_parameters["database"] = dbname
-    return dbutils.generate_uri(connection_parameters)
-
-
 def check_access(connection_uri: str, task: str) -> bool:
     """Checks if the database of interest exists and is accessible. If the database doesn't exist, but the
     task implies its creation, create it. Otherwise exit the program."""
@@ -31,18 +22,6 @@ def check_access(connection_uri: str, task: str) -> bool:
             # Database doesn't exist, and task can't be completed. Return without further action
             print("Database does not exist. Task can't be completed.")
             return False
-
-
-def init(command: str) -> None:
-    """Initiates or resets the default connection parameters"""
-    if command == "init":
-        # Set the default connection parameters
-        dbutils.set_default_parameters()
-    elif command == "reset":
-        # Reset the default connection parameters to factory settings
-        dbutils.reset_default_parameters()
-    else:
-        print("Functionality '" + command + "' is not yet implemented.")
 
 
 def run_command_with_arguments(command: str, sub_command: str, arguments, connection_uri: str) -> None:

--- a/pychado/tests/arguments_tests.py
+++ b/pychado/tests/arguments_tests.py
@@ -5,12 +5,6 @@ from .. import chado_tools
 class TestCommands(unittest.TestCase):
     """Tests if all implemented commands and sub-commands are available through the entry point"""
 
-    def test_init_commands(self):
-        commands = chado_tools.init_commands()
-        self.assertEqual(len(commands), 2)
-        self.assertIn("init", commands)
-        self.assertIn("reset", commands)
-
     def test_general_commands(self):
         commands = chado_tools.general_commands()
         self.assertEqual(len(commands), 2)
@@ -88,13 +82,15 @@ class TestArguments(unittest.TestCase):
         args = ["chado", "connect", "-c", "testconfig", "-V", "testdb"]
         parsed_args = vars(chado_tools.parse_arguments(args))
         self.assertEqual(parsed_args["config"], "testconfig")
-        self.assertEqual(parsed_args["dbname"], "testdb")
+        self.assertFalse(parsed_args["use_password"])
         self.assertTrue(parsed_args["verbose"])
+        self.assertEqual(parsed_args["dbname"], "testdb")
 
         # Test the default values
-        args = ["chado", "connect", "testdb"]
+        args = ["chado", "connect", "-p", "testdb"]
         parsed_args = vars(chado_tools.parse_arguments(args))
         self.assertEqual(parsed_args["config"], "")
+        self.assertTrue(parsed_args["use_password"])
         self.assertFalse(parsed_args["verbose"])
         self.assertNotIn("non_existent_argument", parsed_args)
 

--- a/pychado/utils.py
+++ b/pychado/utils.py
@@ -102,7 +102,7 @@ def write_csv(filename: str, delimiter: str, content: list) -> None:
 def parse_yaml(filename: str) -> dict:
     """Function parsing a YAML file"""
     stream = open_file_read(filename)
-    data = yaml.load(stream)
+    data = yaml.load(stream, Loader=yaml.BaseLoader)
     for key, value in data.items():
         if value is not None:
             data[key] = str(value).strip()
@@ -113,7 +113,7 @@ def parse_yaml(filename: str) -> dict:
 def dump_yaml(filename: str, data: dict) -> None:
     """Function dumping data into a YAML file"""
     stream = open_file_write(filename)
-    yaml.dump(data, stream)
+    yaml.dump(data, stream, Dumper=yaml.BaseDumper)
     close(stream)
 
 

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ except FileNotFoundError or FileExistsError:
 
 setuptools.setup(
     name="chado-tools",
-    version="0.2.11",
+    version="0.2.12",
     author="Christoph Puethe",
     author_email="path-help@sanger.ac.uk",
     description="Tools to access CHADO databases",
@@ -38,13 +38,13 @@ setuptools.setup(
         "nose >= 1.3"
     ],
     install_requires=[
-        "sqlalchemy",
-        "sqlalchemy-utils",
-        "psycopg2-binary",
-        "pyyaml",
+        "sqlalchemy >= 1.3.3",
+        "sqlalchemy-utils >= 0.34.0",
+        "psycopg2 >= 2.7.6",
+        "pyyaml >= 5.1",
         "pronto >= 0.11.0",
-        "gffutils",
-        "biopython"
+        "gffutils >= 0.9",
+        "biopython >= 1.73"
     ],
     license="GPLv3",
     classifiers=[


### PR DESCRIPTION
- remove chado init/reset
- by default read configuration parameters from environment variables
- option to supply a password
- update tests
- update README
- set minimum versions for all dependencies
- use psycopg2 instead of "binary" build
- use "safe" YAML loader
- raise version number